### PR TITLE
Clean up deployment engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,12 @@ Note: Starting the server and running work pool is unnecessary if local Mac Pref
 4. Deploy and run the edge pipeline:
    ```shell
    echodataflow-deploy run \
-   --source-mode local \
    --default-work-pool-name local \
    --param-config REPO_DIRECTORY/recipes/params/params_{MISSION_NAME}.yaml \
    --deploy-spec REPO_DIRECTORY/recipes/deploy/deploy_{MISSION_NAME}.yaml
    ```
+   The deployment source is selected from the `source` section in the deploy recipe.
+   If not set, it is default to using the local codebase.
 
 
 ## Running the cloud pipeline
@@ -101,11 +102,12 @@ Note: Starting the server and running work pool is unnecessary if local Mac Pref
 5. Deploy and run the cloud pipeline:
    ```bash
    echodataflow-deploy run \
-   --source-mode local \
    --default-work-pool-name local \
    --param-config REPO_DIRECTORY/recipes/params/params_{MISSION_NAME}.yaml \
    --deploy-spec REPO_DIRECTORY/recipes/deploy/deploy_{MISSION_NAME}.yaml
    ```
+   The deployment source is selected from the `source` section in the deploy recipe.
+   If not set, it is default to using the local codebase.
 
 6. Start up system services that hosts the 2 sets of visualization
 

--- a/src/echodataflow/deployment/core.py
+++ b/src/echodataflow/deployment/core.py
@@ -1,4 +1,15 @@
-
-
-DEFAULT_MODULE_PREFIX = "echodataflow.flows"
 DEFAULT_ENTRYPOINT_ROOT = "echodataflow/flows"
+
+ALLOWED_DEPLOY_KEYS = {"flow_start_time", "default_work_pool_name", "source", "flows"}
+ALLOWED_FLOW_DEPLOY_KEYS = {
+    "deployment_name",
+    "flow_alias",
+    "interval",
+    "cron_offset",
+    "triggers",
+    "inject_time_offset",
+    "work_pool_name",
+}
+ALLOWED_TRIGGER_KEYS = {"expect", "resource_name"}
+ALLOWED_SOURCE_KEYS = {"mode", "git"}
+ALLOWED_GIT_SOURCE_KEYS = {"url", "branch"}

--- a/src/echodataflow/deployment/deploy_cli.py
+++ b/src/echodataflow/deployment/deploy_cli.py
@@ -89,6 +89,7 @@ def _run_from_specs(
         param_cfg=param_cfg,
         deploy_cfg=deploy_cfg,
         source=source,
+        default_work_pool_name=default_work_pool_name,
     )
 
     deploy(*grouped, work_pool_name=default_work_pool_name)

--- a/src/echodataflow/deployment/deploy_cli.py
+++ b/src/echodataflow/deployment/deploy_cli.py
@@ -4,15 +4,11 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import importlib
-import inspect
 from pathlib import Path
 from typing import Any
 
 from prefect import deploy
 from prefect.variables import Variable
-
-from yaml import safe_load
 
 
 from echodataflow.deployment.deployment_engine import (
@@ -26,25 +22,58 @@ from echodataflow.deployment.deployment_engine import (
 )
 
 
-def _run_concurrency_setup(filtered_flows: dict[str, dict[str, Any]]) -> None:
-    """Run set_concurrency_limit for modules with flows in filtered_flows."""
-    seen_modules = set()
-    
-    for flow_info in filtered_flows.values():
-        flow_module = flow_info["flow_module"]
-        module_name = id(flow_module)  # use object id to track unique modules
-        if module_name in seen_modules:
-            continue
-        seen_modules.add(module_name)
-        
-        setup_fn = getattr(flow_module, "set_concurrency_limit", None)
-        if not callable(setup_fn):
+def _run_concurrency_setup(deploy_cfg: dict[str, Any]) -> None:
+    """Create Prefect concurrency limits declared on individual flow configs."""
+    concurrency_by_tag: dict[str, int] = {}
+
+    for flow_key, deploy_meta in deploy_cfg.get("flows", {}).items():
+        if not isinstance(deploy_meta, dict):
             continue
 
-        if inspect.iscoroutinefunction(setup_fn):
-            asyncio.run(setup_fn())
-        else:
-            setup_fn()
+        concurrency_limit = deploy_meta.get("concurrency_limit")
+        if concurrency_limit is None:
+            continue
+        if not isinstance(concurrency_limit, int) or concurrency_limit < 1:
+            raise ValueError(
+                f"deploy_cfg.flows.{flow_key}.concurrency_limit must be an integer >= 1"
+            )
+
+        concurrency_tag = deploy_meta.get("concurrency_tag", flow_key)
+        if not isinstance(concurrency_tag, str) or not concurrency_tag.strip():
+            raise ValueError(
+                f"deploy_cfg.flows.{flow_key}.concurrency_tag must be a non-empty string"
+            )
+        concurrency_tag = concurrency_tag.strip()
+
+        existing_limit = concurrency_by_tag.get(concurrency_tag)
+        if existing_limit is not None and existing_limit != concurrency_limit:
+            raise ValueError(
+                f"Conflicting concurrency_limit for tag {concurrency_tag!r}: "
+                f"{existing_limit} != {concurrency_limit}"
+            )
+        concurrency_by_tag[concurrency_tag] = concurrency_limit
+
+    if not concurrency_by_tag:
+        return
+
+    from prefect import get_client
+    from prefect.exceptions import ObjectAlreadyExists, ObjectNotFound
+
+    async def ensure_concurrency_limits() -> None:
+        async with get_client() as client:
+            for concurrency_tag, concurrency_limit in concurrency_by_tag.items():
+                try:
+                    await client.read_concurrency_limit_by_tag(concurrency_tag)
+                except ObjectNotFound:
+                    try:
+                        await client.create_concurrency_limit(
+                            tag=concurrency_tag,
+                            concurrency_limit=concurrency_limit,
+                        )
+                    except ObjectAlreadyExists:
+                        pass
+
+    asyncio.run(ensure_concurrency_limits())
 
 
 def _run_from_specs(
@@ -68,7 +97,7 @@ def _run_from_specs(
     all_flows = discover_all_flows()
     filtered_flows = filter_flows_for_deploy(all_flows, deploy_cfg)
     if run_concurrency_setup:
-        _run_concurrency_setup(filtered_flows)
+        _run_concurrency_setup(deploy_cfg)
 
     # Set up deployment source: git or local
     source = resolve_deployment_source(

--- a/src/echodataflow/deployment/deploy_cli.py
+++ b/src/echodataflow/deployment/deploy_cli.py
@@ -16,6 +16,7 @@ from echodataflow.deployment.deployment_engine import (
     create_deployments,
     load_config,
     resolve_deployment_source,
+    validate_deploy_config,
     validate_flow_coverage,
 )
 
@@ -29,7 +30,8 @@ def _run_from_specs(
     param_cfg = load_config(param_cfg_path)
     deploy_cfg = load_config(deploy_cfg_path)
 
-    # Validate the pair of configs contain the same flows
+    # Validate the deployment schema and paired flow coverage.
+    validate_deploy_config(deploy_cfg)
     validate_flow_coverage(param_cfg, deploy_cfg)
 
     # Set "flow_start_time" as a Prefect variable

--- a/src/echodataflow/deployment/deploy_cli.py
+++ b/src/echodataflow/deployment/deploy_cli.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Any
 
 from prefect import deploy
+from prefect.variables import Variable
+
 from yaml import safe_load
 
 
@@ -21,7 +23,6 @@ from echodataflow.deployment.deployment_engine import (
     create_deployments,
     load_config,
     resolve_deployment_source,
-    set_prefect_variables,
     validate_flow_coverage,
 )
 
@@ -51,7 +52,7 @@ def _run_from_specs(
     *,
     param_cfg_path: Path,
     deploy_cfg_path: Path,
-    source_mode: str | None,
+    source_mode_override: str | None,
     run_concurrency_setup: bool,
     default_work_pool_name: str = "local",
 ) -> None:
@@ -62,8 +63,8 @@ def _run_from_specs(
     # Validate the pair of configs contain the same flows
     validate_flow_coverage(param_cfg, deploy_cfg)
 
-    # Set prefect variables
-    set_prefect_variables(deploy_cfg)
+    # Set "flow_start_time" as a Prefect variable
+    Variable.set("flow_start_time", deploy_cfg.get("flow_start_time"), overwrite=True)
 
     # Discover all flows and filter to those in deploy config
     all_flows = discover_all_flows()
@@ -74,7 +75,7 @@ def _run_from_specs(
     # Set up deployment source: git or local
     source = resolve_deployment_source(
         deploy_cfg=deploy_cfg,
-        source_mode_override=source_mode,
+        source_mode_override=source_mode_override,
         log_context="deploy_cli",
     )
 
@@ -152,15 +153,15 @@ def main() -> None:
     parser = _build_parser()
     args = parser.parse_args()
 
-    source_mode = args.source_mode
-    if source_mode is not None:
-        os.environ["PREFECT_SOURCE_MODE"] = source_mode
+    source_mode_override = args.source_mode
+    if source_mode_override is not None:
+        os.environ["PREFECT_SOURCE_MODE"] = source_mode_override
 
     if args.target == "run":
         _run_from_specs(
             param_cfg_path=args.param_config,
             deploy_cfg_path=args.deploy_spec,
-            source_mode=source_mode,
+            source_mode_override=source_mode_override,
             run_concurrency_setup=args.use_concurrency,
             default_work_pool_name=args.default_work_pool_name,
         )

--- a/src/echodataflow/deployment/deploy_cli.py
+++ b/src/echodataflow/deployment/deploy_cli.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import argparse
-import asyncio
 from pathlib import Path
-from typing import Any
 
 from prefect import deploy
 from prefect.variables import Variable
@@ -21,66 +19,10 @@ from echodataflow.deployment.deployment_engine import (
     validate_flow_coverage,
 )
 
-
-def _run_concurrency_setup(deploy_cfg: dict[str, Any]) -> None:
-    """Create Prefect concurrency limits declared on individual flow configs."""
-    concurrency_by_tag: dict[str, int] = {}
-
-    for flow_key, deploy_meta in deploy_cfg.get("flows", {}).items():
-        if not isinstance(deploy_meta, dict):
-            continue
-
-        concurrency_limit = deploy_meta.get("concurrency_limit")
-        if concurrency_limit is None:
-            continue
-        if not isinstance(concurrency_limit, int) or concurrency_limit < 1:
-            raise ValueError(
-                f"deploy_cfg.flows.{flow_key}.concurrency_limit must be an integer >= 1"
-            )
-
-        concurrency_tag = deploy_meta.get("concurrency_tag", flow_key)
-        if not isinstance(concurrency_tag, str) or not concurrency_tag.strip():
-            raise ValueError(
-                f"deploy_cfg.flows.{flow_key}.concurrency_tag must be a non-empty string"
-            )
-        concurrency_tag = concurrency_tag.strip()
-
-        existing_limit = concurrency_by_tag.get(concurrency_tag)
-        if existing_limit is not None and existing_limit != concurrency_limit:
-            raise ValueError(
-                f"Conflicting concurrency_limit for tag {concurrency_tag!r}: "
-                f"{existing_limit} != {concurrency_limit}"
-            )
-        concurrency_by_tag[concurrency_tag] = concurrency_limit
-
-    if not concurrency_by_tag:
-        return
-
-    from prefect import get_client
-    from prefect.exceptions import ObjectAlreadyExists, ObjectNotFound
-
-    async def ensure_concurrency_limits() -> None:
-        async with get_client() as client:
-            for concurrency_tag, concurrency_limit in concurrency_by_tag.items():
-                try:
-                    await client.read_concurrency_limit_by_tag(concurrency_tag)
-                except ObjectNotFound:
-                    try:
-                        await client.create_concurrency_limit(
-                            tag=concurrency_tag,
-                            concurrency_limit=concurrency_limit,
-                        )
-                    except ObjectAlreadyExists:
-                        pass
-
-    asyncio.run(ensure_concurrency_limits())
-
-
 def _run_from_specs(
     *,
     param_cfg_path: Path,
     deploy_cfg_path: Path,
-    run_concurrency_setup: bool,
     default_work_pool_name: str = "local",
 ) -> None:
     # Load configs
@@ -96,8 +38,6 @@ def _run_from_specs(
     # Discover all flows and filter to those in deploy config
     all_flows = discover_all_flows()
     filtered_flows = filter_flows_for_deploy(all_flows, deploy_cfg)
-    if run_concurrency_setup:
-        _run_concurrency_setup(deploy_cfg)
 
     # Set up deployment source: git or local
     source = resolve_deployment_source(
@@ -156,13 +96,6 @@ def _build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Path to deploy_*.yaml (deployment spec).",
     )
-    run_parser.add_argument(
-        "--use-concurrency",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Run concurrency-limit setup before creating deployments (default: enabled).",
-    )
-
     return parser
 
 
@@ -174,7 +107,6 @@ def main() -> None:
         _run_from_specs(
             param_cfg_path=args.param_config,
             deploy_cfg_path=args.deploy_spec,
-            run_concurrency_setup=args.use_concurrency,
             default_work_pool_name=args.default_work_pool_name,
         )
         return

--- a/src/echodataflow/deployment/deploy_cli.py
+++ b/src/echodataflow/deployment/deploy_cli.py
@@ -110,13 +110,12 @@ def _run_from_specs(
     default_work_pool_name = deploy_cfg.get("default_work_pool_name", default_work_pool_name)
 
     specs = build_deploy_specs(
+        param_cfg=param_cfg,
         deploy_cfg=deploy_cfg,
         filtered_flows=filtered_flows,
     )
     grouped, standalone = create_deployments(
         specs=specs,
-        param_cfg=param_cfg,
-        deploy_cfg=deploy_cfg,
         source=source,
         default_work_pool_name=default_work_pool_name,
     )

--- a/src/echodataflow/deployment/deploy_cli.py
+++ b/src/echodataflow/deployment/deploy_cli.py
@@ -6,7 +6,6 @@ import argparse
 import asyncio
 import importlib
 import inspect
-import os
 from pathlib import Path
 from typing import Any
 
@@ -52,7 +51,6 @@ def _run_from_specs(
     *,
     param_cfg_path: Path,
     deploy_cfg_path: Path,
-    source_mode_override: str | None,
     run_concurrency_setup: bool,
     default_work_pool_name: str = "local",
 ) -> None:
@@ -75,7 +73,6 @@ def _run_from_specs(
     # Set up deployment source: git or local
     source = resolve_deployment_source(
         deploy_cfg=deploy_cfg,
-        source_mode_override=source_mode_override,
         log_context="deploy_cli",
     )
 
@@ -111,15 +108,6 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Run deployments from explicit YAML file paths.",
     )
     run_parser.add_argument(
-        "--source-mode",
-        choices=("local", "git"),
-        default=None,
-        help=(
-            "Temporarily override source selection for this run. "
-            "Maps to PREFECT_SOURCE_MODE."
-        ),
-    )
-    run_parser.add_argument(
         "--default-work-pool-name",
         required=True,
         default="local",
@@ -153,15 +141,10 @@ def main() -> None:
     parser = _build_parser()
     args = parser.parse_args()
 
-    source_mode_override = args.source_mode
-    if source_mode_override is not None:
-        os.environ["PREFECT_SOURCE_MODE"] = source_mode_override
-
     if args.target == "run":
         _run_from_specs(
             param_cfg_path=args.param_config,
             deploy_cfg_path=args.deploy_spec,
-            source_mode_override=source_mode_override,
             run_concurrency_setup=args.use_concurrency,
             default_work_pool_name=args.default_work_pool_name,
         )

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import inspect
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -377,6 +378,21 @@ def validate_flow_coverage(
         raise ValueError("Flow coverage mismatch. " + " | ".join(errors))
 
 
+def _flow_accepts_time_offset_seconds(flow_obj: Any) -> bool:
+    """Return True when the flow function can accept `time_offset_seconds`.
+
+    Prefect Flow objects expose the wrapped function via `.fn`. If a flow object
+    does not expose an inspectable function (e.g. certain test doubles), we skip
+    strict validation and allow the deployment build to proceed.
+    """
+    flow_fn = getattr(flow_obj, "fn", None)
+    if not callable(flow_fn):
+        return True
+
+    signature = inspect.signature(flow_fn)
+    return "time_offset_seconds" in signature.parameters
+
+
 def build_deploy_specs(
     *,
     param_cfg: dict[str, Any],
@@ -413,6 +429,16 @@ def build_deploy_specs(
             )
 
         flow_info = filtered_flows[key]
+
+        # Check if time_offset_seconds is indeed accepted by the flows specified in deploy config
+        if (
+            key in time_offset_targets
+            and not _flow_accepts_time_offset_seconds(flow_info["flow_obj"])
+        ):
+            raise ValueError(
+                f"deploy_cfg.flows.{key}.inject_time_offset is enabled, "
+                "but the target flow does not define 'time_offset_seconds'"
+            )
 
         # Set up triggers or cron schedule based on deploy config
         triggers = validate_triggers(

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import datetime
 from dataclasses import dataclass
 from pathlib import Path
-from types import ModuleType
 from typing import Any, cast
 import importlib.util
 
@@ -24,14 +23,11 @@ DEFAULT_DEPLOYMENT_WRAPPER_ENTRYPOINT = "echodataflow/flows/flows_helper.py:flow
 class DeploymentSpec:
     flow_key: str  # the flow key from deploy config, used to look up flow params and deploy settings
     deployment_name: str  # the deployment name to use for this flow
-    flow_module: str  # the module name as string
-    flow_name: str  # the flow function name including flow_ prefix
-    flow_obj: Flow[..., Any] | None = None  # the actual Flow object, resolved from flow_module and flow_name
-    flow_alias: str | None = None  # an optional alias for the flow, used for deployment naming
-    cron_offset: int = 0  # the cron offset in minutes, used to stagger deployments
+    flow_obj: Flow[..., Any]  # the actual Flow object resolved from discovered flow metadata
+    parameters: dict[str, Any]  # fully compiled deployment parameters passed to the wrapper
+    cron: str | None = None  # precomputed cron schedule, when interval mode is used
     work_pool_name: str | None = None  # the work pool name to use for this deployment, if different from default
-    triggers: list[dict[str, Any]] | None = None  # a list of trigger definitions, each with 'expect' and 'resource_name' keys
-    emit_events: list[str] | None = None  # a list of event names to emit after the flow completes, used for triggering downstream flows
+    triggers: list[Any] | None = None  # precomputed Prefect trigger objects
 
 
 def discover_all_flows() -> dict[str, dict[str, Any]]:
@@ -54,17 +50,17 @@ def discover_all_flows() -> dict[str, dict[str, Any]]:
         
         module_name = py_file.stem  # filename without .py
         try:
-            flow_module = importlib.import_module(f"echodataflow.flows.{module_name}")
+            flow_module_obj = importlib.import_module(f"echodataflow.flows.{module_name}")
         except ImportError as e:
             raise ImportError(f"Failed to import echodataflow.flows.{module_name}: {e}")
         
         # Find all flow_* attributes in the module
-        for flow_function_name in dir(flow_module):
+        for flow_function_name in dir(flow_module_obj):
             if not flow_function_name.startswith("flow_"):
                 continue
 
             flow_name = flow_function_name.removeprefix("flow_")
-            flow_obj = cast(Flow[..., Any], getattr(flow_module, flow_function_name))
+            flow_obj = cast(Flow[..., Any], getattr(flow_module_obj, flow_function_name))
             
             discovered[flow_name] = {
                 "flow_module": module_name,  # the module name as string
@@ -383,13 +379,18 @@ def validate_flow_coverage(
 
 def build_deploy_specs(
     *,
+    param_cfg: dict[str, Any],
     deploy_cfg: dict[str, Any],
     filtered_flows: dict[str, dict[str, Any]],
 ) -> list[DeploymentSpec]:
     """
-    Build deployment specs from deploy config and pre-filtered flows mapping.
+    Build deployment specs from deploy/param config and pre-filtered flows mapping.
+    Specs contain fully compiled parameters and schedule/trigger metadata.
     """
     specs: list[DeploymentSpec] = []
+    flows_params = param_cfg["flows"]
+    time_offset_targets = get_time_offset_targets(deploy_cfg)
+    time_offset_seconds = _compute_time_offset_seconds(deploy_cfg.get("flow_start_time"))
 
     for key, deploy_meta in deploy_cfg.get("flows", {}).items():
         if not isinstance(deploy_meta, dict):
@@ -411,29 +412,51 @@ def build_deploy_specs(
                 f"deploy_cfg.flows.{key} must define exactly one of 'triggers' or 'interval'"
             )
 
-        # Validate triggers and emit_events if provided
         flow_info = filtered_flows[key]
+
+        # Set up triggers or cron schedule based on deploy config
         triggers = validate_triggers(
             deploy_meta.get("triggers"),
             flow_key=key,
         )
+        compiled_triggers = build_triggers(triggers) if triggers is not None else None
+
+        cron: str | None = None
+        if compiled_triggers is None:
+            interval = deploy_meta.get("interval")
+            cron = build_cron(interval, deploy_meta.get("cron_offset", 0))
+
+        # Build deployment_parameters
+        flow_params = flows_params.get(key)
+        if not isinstance(flow_params, dict):
+            raise ValueError(
+                f"param_cfg.flows.{key} must be a mapping of flow parameters"
+            )
+
+        deployment_parameters = dict(flow_params)
+        if key in time_offset_targets:
+            deployment_parameters["time_offset_seconds"] = time_offset_seconds
+
+        deployment_parameters["flow_module"] = flow_info["flow_module"]
+        deployment_parameters["flow_name"] = flow_info["flow_function_name"]
+
+        # Add emit_events if configured in deploy config
         emit_events = validate_emit_events(
             deploy_meta.get("emit_events"),
             flow_key=key,
         )
+        if emit_events is not None:
+            deployment_parameters["emit_events"] = emit_events
 
         specs.append(
             DeploymentSpec(
                 flow_key=key,
                 deployment_name=deploy_meta.get("deployment_name", key),
-                flow_module=flow_info["flow_module"],
-                flow_name=flow_info["flow_function_name"],
                 flow_obj=flow_info["flow_obj"],
-                flow_alias=deploy_meta.get("flow_alias"),
-                cron_offset=deploy_meta.get("cron_offset", 0),
+                parameters=deployment_parameters,
+                cron=cron,
                 work_pool_name=deploy_meta.get("work_pool_name"),
-                triggers=triggers,
-                emit_events=emit_events,
+                triggers=compiled_triggers,
             )
         )
 
@@ -443,47 +466,24 @@ def build_deploy_specs(
 def create_deployments(
     *,
     specs: list[DeploymentSpec],
-    param_cfg: dict[str, Any],
-    deploy_cfg: dict[str, Any],
     source: Any,
     default_work_pool_name: str,
 ) -> tuple[list[RunnerDeployment], list[RunnerDeployment]]:
-    flows_params = param_cfg["flows"]
-    flows_deploy_settings = deploy_cfg["flows"]
-    time_offset_targets = get_time_offset_targets(deploy_cfg)
-    time_offset_seconds = _compute_time_offset_seconds(deploy_cfg.get("flow_start_time"))
-
     grouped: list[RunnerDeployment] = []
     standalone: list[RunnerDeployment] = []
 
     for spec in specs:
-        if spec.flow_obj is None:
-            raise ValueError(f"Deployment spec '{spec.deployment_name}' has no resolved flow")
         flow_obj = spec.flow_obj
         deployment_kwargs: dict[str, Any] = {
             "name": spec.deployment_name,
-            "parameters": dict(flows_params[spec.flow_key]),
+            "parameters": dict(spec.parameters),
         }
 
-        # Inject time_offset_seconds if this flow is marked for it
-        if spec.flow_key in time_offset_targets:
-            deployment_kwargs["parameters"]["time_offset_seconds"] = time_offset_seconds
-
-        # Always route through the generic deployment wrapper so deployment-level
-        # behavior can be configured centrally without changing flow functions
-        deployment_kwargs["parameters"]["flow_module"] = spec.flow_module
-        deployment_kwargs["parameters"]["flow_name"] = spec.flow_name
-        if spec.emit_events is not None:
-            deployment_kwargs["parameters"]["emit_events"] = spec.emit_events
-
-        # Build triggers or cron schedule for the deployment
+        # Use precomputed schedule metadata from the deployment spec
         if spec.triggers is not None:
-            deployment_kwargs["triggers"] = build_triggers(spec.triggers)
-        else:
-            interval = flows_deploy_settings[spec.flow_key].get("interval")
-            cron = build_cron(interval, spec.cron_offset)
-            if cron is not None:
-                deployment_kwargs["cron"] = cron
+            deployment_kwargs["triggers"] = spec.triggers
+        elif spec.cron is not None:
+            deployment_kwargs["cron"] = spec.cron
 
         # Add work_pool_name if specified and different from default
         has_non_default_work_pool = (

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -165,7 +165,6 @@ def _validate_local_source_layout(local_source_root: Path) -> Path:
 
 def resolve_deployment_source(
     deploy_cfg: dict[str, Any],
-    source_mode_override: str | None = None,
     log_context: str | None = None,
 ) -> Any:
     """
@@ -175,13 +174,10 @@ def resolve_deployment_source(
     if source_cfg is None:
         source_cfg = {}
 
-    # Priority: 1) env var override, 2) deploy config setting, 3) default to local
-    mode = (source_mode_override or source_cfg.get("mode") or "local").lower()
+    # Priority: 1) deploy config setting, 2) default to local
+    mode = (source_cfg.get("mode") or "local").lower()
 
-    # Capture the origin of source mode
-    if source_mode_override:
-        source_mode_origin = "env:PREFECT_SOURCE_MODE"
-    elif source_cfg.get("mode"):
+    if source_cfg.get("mode"):
         source_mode_origin = "deploy_cfg.source.mode"
     else:
         source_mode_origin = "default:local"

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -245,11 +245,6 @@ def build_cron(interval: int | None, cron_offset: int = 0) -> str | None:
     return f"*/{interval} * * * *"
 
 
-# TODO: decide if want to keep this
-def sanitize_parameters(flow_cfg: dict[str, Any]) -> dict[str, Any]:
-    return dict(flow_cfg)
-
-
 def build_triggers(trigger_items: list[dict[str, Any]]) -> list[Any]:
     return [
         DeploymentEventTrigger(
@@ -401,7 +396,7 @@ def create_deployments(
         flow_obj = spec.flow_obj
         deployment_kwargs: dict[str, Any] = {
             "name": spec.deployment_name,
-            "parameters": sanitize_parameters(flows_params[spec.flow_key]),
+            "parameters": dict(flows_params[spec.flow_key]),
         }
 
         # Inject time_offset_seconds if this flow is marked for it

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -389,9 +389,9 @@ def build_deploy_specs(
             )
 
         # Raise error if both triggers and cron are specified in deploy config
-        if (deploy_meta.get("triggers") is None) == (deploy_meta.get("interval") is None):
+        if (deploy_meta.get("triggers") is not None) and (deploy_meta.get("interval") is not None):
             raise ValueError(
-                f"deploy_cfg.flows.{key} must define exactly one of 'triggers' or 'interval'"
+                f"deploy_cfg.flows.{key} must define only one of 'triggers' or 'interval'"
             )
 
         flow_info = filtered_flows[key]

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -349,6 +349,11 @@ def build_deploy_specs(
                 "entrypoint is discovered from the flow module"
             )
 
+        if (deploy_meta.get("triggers") is None) == (deploy_meta.get("interval") is None):
+            raise ValueError(
+                f"deploy_cfg.flows.{key} must define exactly one of 'triggers' or 'interval'"
+            )
+
         flow_info = filtered_flows[key]
         emit_events = validate_emit_events(
             deploy_meta.get("emit_events"),

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -30,7 +30,6 @@ class DeploymentSpec:
     flow_obj: Flow[..., Any] | None = None
     flow_alias: str | None = None
     cron_offset: int = 0
-    apply_separately: bool = False
     work_pool_name: str | None = None
     triggers: list[dict[str, Any]] | None = None
     emit_events: list[str] | None = None
@@ -349,6 +348,7 @@ def build_deploy_specs(
                 "entrypoint is discovered from the flow module"
             )
 
+        # Raise error if both triggers and cron are specified in deploy config
         if (deploy_meta.get("triggers") is None) == (deploy_meta.get("interval") is None):
             raise ValueError(
                 f"deploy_cfg.flows.{key} must define exactly one of 'triggers' or 'interval'"
@@ -370,7 +370,6 @@ def build_deploy_specs(
                 flow_obj=flow_info["flow_obj"],
                 flow_alias=deploy_meta.get("flow_alias"),
                 cron_offset=deploy_meta.get("cron_offset", 0),
-                apply_separately=deploy_meta.get("apply_separately", False),
                 work_pool_name=deploy_meta.get("work_pool_name"),
                 triggers=deploy_meta.get("triggers"),
                 emit_events=emit_events,
@@ -386,6 +385,7 @@ def create_deployments(
     param_cfg: dict[str, Any],
     deploy_cfg: dict[str, Any],
     source: Any,
+    default_work_pool_name: str,
 ) -> tuple[list[RunnerDeployment], list[RunnerDeployment]]:
     flows_params = param_cfg["flows"]
     flows_deploy_settings = deploy_cfg["flows"]
@@ -418,7 +418,6 @@ def create_deployments(
             spec_entrypoint = spec.entrypoint
 
         # Build triggers or cron schedule for the deployment
-        # TODO: raise error if both triggers and cron are specified in deploy config
         if spec.triggers is not None:
             deployment_kwargs["triggers"] = build_triggers(spec.triggers)
         else:
@@ -427,7 +426,11 @@ def create_deployments(
             if cron is not None:
                 deployment_kwargs["cron"] = cron
 
-        if spec.work_pool_name is not None:
+        # Add work_pool_name if specified and different from default
+        has_non_default_work_pool = (
+            spec.work_pool_name is not None and spec.work_pool_name != default_work_pool_name
+        )
+        if has_non_default_work_pool:
             deployment_kwargs["work_pool_name"] = spec.work_pool_name
 
         deployment = (
@@ -437,7 +440,7 @@ def create_deployments(
             ).to_deployment(**deployment_kwargs)
         )
 
-        if spec.apply_separately or spec.work_pool_name is not None:
+        if has_non_default_work_pool:
             standalone.append(deployment)
         else:
             grouped.append(deployment)

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -15,7 +15,14 @@ from prefect.flows import Flow
 from prefect.variables import Variable
 from yaml import safe_load
 
-from echodataflow.deployment.core import DEFAULT_ENTRYPOINT_ROOT
+from echodataflow.deployment.core import (
+    ALLOWED_DEPLOY_KEYS,
+    ALLOWED_FLOW_DEPLOY_KEYS,
+    ALLOWED_GIT_SOURCE_KEYS,
+    ALLOWED_SOURCE_KEYS,
+    ALLOWED_TRIGGER_KEYS,
+    DEFAULT_ENTRYPOINT_ROOT,
+)
 
 
 @dataclass(frozen=True)
@@ -249,6 +256,67 @@ def build_triggers(trigger_items: list[dict[str, Any]]) -> list[Any]:
     ]
 
 
+def _reject_unknown_keys(
+    value: dict[str, Any],
+    *,
+    allowed: set[str],
+    path: str,
+) -> None:
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise ValueError(f"Unsupported field(s) at {path}: {unknown}")
+
+
+def validate_deploy_config(deploy_cfg: Any) -> None:
+    """Reject unknown fields throughout a deployment specification."""
+    if not isinstance(deploy_cfg, dict):
+        raise ValueError("deploy_cfg must be a mapping")
+
+    _reject_unknown_keys(deploy_cfg, allowed=ALLOWED_DEPLOY_KEYS, path="deploy_cfg")
+
+    flows = deploy_cfg.get("flows")
+    if not isinstance(flows, dict):
+        raise ValueError("deploy_cfg.flows must be a mapping")
+
+    for flow_key, deploy_meta in flows.items():
+        flow_path = f"deploy_cfg.flows.{flow_key}"
+        if not isinstance(deploy_meta, dict):
+            raise ValueError(f"{flow_path} must be a mapping")
+        _reject_unknown_keys(
+            deploy_meta,
+            allowed=ALLOWED_FLOW_DEPLOY_KEYS,
+            path=flow_path,
+        )
+
+        triggers = deploy_meta.get("triggers")
+        if isinstance(triggers, list):
+            for index, trigger in enumerate(triggers):
+                if isinstance(trigger, dict):
+                    _reject_unknown_keys(
+                        trigger,
+                        allowed=ALLOWED_TRIGGER_KEYS,
+                        path=f"{flow_path}.triggers[{index}]",
+                    )
+
+    source = deploy_cfg.get("source")
+    if source is None:
+        return
+    if not isinstance(source, dict):
+        raise ValueError("deploy_cfg.source must be a mapping")
+    _reject_unknown_keys(source, allowed=ALLOWED_SOURCE_KEYS, path="deploy_cfg.source")
+
+    git_source = source.get("git")
+    if git_source is None:
+        return
+    if not isinstance(git_source, dict):
+        raise ValueError("deploy_cfg.source.git must be a mapping")
+    _reject_unknown_keys(
+        git_source,
+        allowed=ALLOWED_GIT_SOURCE_KEYS,
+        path="deploy_cfg.source.git",
+    )
+
+
 def validate_optional_non_empty_list(
     value: Any,
     *,
@@ -369,6 +437,8 @@ def build_deploy_specs(
     Build deployment specs from deploy/param config and pre-filtered flows mapping.
     Specs contain fully compiled parameters and schedule/trigger metadata.
     """
+    validate_deploy_config(deploy_cfg)
+
     specs: list[DeploymentSpec] = []
     flows_params = param_cfg["flows"]
     time_offset_targets = get_time_offset_targets(deploy_cfg)
@@ -381,15 +451,11 @@ def build_deploy_specs(
         if key not in filtered_flows:
             continue
 
-        # Disallow specifying entrypoint in deploy config
-        if "entrypoint" in deploy_meta:
-            raise ValueError(
-                f"deploy_cfg.flows.{key}.entrypoint is not supported; "
-                "entrypoint is discovered from the flow module"
-            )
-
-        # Raise error if both triggers and cron are specified in deploy config
-        if (deploy_meta.get("triggers") is not None) and (deploy_meta.get("interval") is not None):
+        # Scheduling is optional for manually run deployments, but the two
+        # supported scheduling mechanisms are mutually exclusive.
+        if (deploy_meta.get("triggers") is not None) and (
+            deploy_meta.get("interval") is not None
+        ):
             raise ValueError(
                 f"deploy_cfg.flows.{key} must define only one of 'triggers' or 'interval'"
             )

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -17,14 +17,13 @@ from yaml import safe_load
 
 from echodataflow.deployment.core import DEFAULT_ENTRYPOINT_ROOT
 
-DEFAULT_EMIT_EVENTS_ENTRYPOINT = "echodataflow/flows/flows_helper.py:flow_emit_events_wrapper"
+DEFAULT_DEPLOYMENT_WRAPPER_ENTRYPOINT = "echodataflow/flows/flows_helper.py:flow_deployment_wrapper"
 
 
 @dataclass(frozen=True)
 class DeploymentSpec:
     flow_key: str
     deployment_name: str
-    entrypoint: str
     flow_module: str
     flow_name: str
     flow_obj: Flow[..., Any] | None = None
@@ -415,6 +414,7 @@ def build_deploy_specs(
                 f"deploy_cfg.flows.{key} must define exactly one of 'triggers' or 'interval'"
             )
 
+        # Validate triggers and emit_events if provided
         flow_info = filtered_flows[key]
         triggers = validate_triggers(
             deploy_meta.get("triggers"),
@@ -429,7 +429,6 @@ def build_deploy_specs(
             DeploymentSpec(
                 flow_key=key,
                 deployment_name=deploy_meta.get("deployment_name", key),
-                entrypoint=flow_info["entrypoint"],
                 flow_module=flow_info["module_name"],
                 flow_name=flow_info["flow_function_name"],
                 flow_obj=flow_info["flow_obj"],
@@ -473,14 +472,12 @@ def create_deployments(
         if spec.flow_key in time_offset_targets:
             deployment_kwargs["parameters"]["time_offset_seconds"] = time_offset_seconds
 
-        # If emit_events is configured, run the generic wrapper flow instead.
+        # Always route through the generic deployment wrapper so deployment-level
+        # behavior can be configured centrally without changing flow functions
+        deployment_kwargs["parameters"]["flow_module"] = spec.flow_module
+        deployment_kwargs["parameters"]["flow_name"] = spec.flow_name
         if spec.emit_events is not None:
-            deployment_kwargs["parameters"]["flow_module"] = spec.flow_module
-            deployment_kwargs["parameters"]["flow_name"] = spec.flow_name
             deployment_kwargs["parameters"]["emit_events"] = spec.emit_events
-            spec_entrypoint = DEFAULT_EMIT_EVENTS_ENTRYPOINT
-        else:
-            spec_entrypoint = spec.entrypoint
 
         # Build triggers or cron schedule for the deployment
         if spec.triggers is not None:
@@ -501,7 +498,7 @@ def create_deployments(
         deployment = (
             flow_obj.from_source(
                 source=source,
-                entrypoint=spec_entrypoint,
+                entrypoint=DEFAULT_DEPLOYMENT_WRAPPER_ENTRYPOINT,
             ).to_deployment(**deployment_kwargs)
         )
 

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -256,6 +256,71 @@ def build_triggers(trigger_items: list[dict[str, Any]]) -> list[Any]:
     ]
 
 
+def validate_optional_non_empty_list(
+    value: Any,
+    *,
+    field_name: str,
+    item_label: str,
+) -> list[Any] | None:
+    """Validate an optional list field that must be non-empty when provided."""
+    if value is None:
+        return None
+
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be a list")
+    if len(value) == 0:
+        raise ValueError(f"{field_name} must contain at least one {item_label}")
+
+    return value
+
+
+def validate_triggers(
+    triggers: Any,
+    *,
+    flow_key: str,
+) -> list[dict[str, Any]] | None:
+    """
+    Validate deployment trigger config.
+
+    When configured, triggers must be a non-empty list of mappings with
+    non-empty string values for `expect` and `resource_name`.
+    """
+    triggers = validate_optional_non_empty_list(
+        triggers,
+        field_name=f"deploy_cfg.flows.{flow_key}.triggers",
+        item_label="trigger",
+    )
+    if triggers is None:
+        return None
+
+    validated_triggers: list[dict[str, Any]] = []
+    for trigger_item in triggers:
+        if not isinstance(trigger_item, dict):
+            raise ValueError(
+                f"deploy_cfg.flows.{flow_key}.triggers entries must be mappings"
+            )
+
+        expect = trigger_item.get("expect")
+        resource_name = trigger_item.get("resource_name")
+        if not isinstance(expect, str) or not expect.strip():
+            raise ValueError(
+                f"deploy_cfg.flows.{flow_key}.triggers entries must define a non-empty 'expect'"
+            )
+        if not isinstance(resource_name, str) or not resource_name.strip():
+            raise ValueError(
+                f"deploy_cfg.flows.{flow_key}.triggers entries must define a non-empty 'resource_name'"
+            )
+
+        validated_triggers.append(
+            {
+                "expect": expect.strip(),
+                "resource_name": resource_name.strip(),
+            }
+        )
+
+    return validated_triggers
+
+
 def validate_emit_events(
     emit_events: Any,
     *,
@@ -266,19 +331,15 @@ def validate_emit_events(
 
     When configured, emit_events must be a non-empty list of non-empty strings.
     """
+    emit_events = validate_optional_non_empty_list(
+        emit_events,
+        field_name=f"deploy_cfg.flows.{flow_key}.emit_events",
+        item_label="event name",
+    )
     if emit_events is None:
         return None
 
-    if not isinstance(emit_events, list):
-        raise ValueError(
-            f"deploy_cfg.flows.{flow_key}.emit_events must be a list of event names"
-        )
-    if len(emit_events) == 0:
-        raise ValueError(
-            f"deploy_cfg.flows.{flow_key}.emit_events must contain at least one event name"
-        )
-
-    sanitized_events: list[str] = []
+    validated_events: list[str] = []
     for event_name in emit_events:
         if not isinstance(event_name, str):
             raise ValueError(
@@ -289,9 +350,9 @@ def validate_emit_events(
             raise ValueError(
                 f"deploy_cfg.flows.{flow_key}.emit_events entries must be non-empty"
             )
-        sanitized_events.append(event_name)
+        validated_events.append(event_name)
 
-    return sanitized_events
+    return validated_events
 
 
 def validate_flow_coverage(
@@ -355,6 +416,10 @@ def build_deploy_specs(
             )
 
         flow_info = filtered_flows[key]
+        triggers = validate_triggers(
+            deploy_meta.get("triggers"),
+            flow_key=key,
+        )
         emit_events = validate_emit_events(
             deploy_meta.get("emit_events"),
             flow_key=key,
@@ -371,7 +436,7 @@ def build_deploy_specs(
                 flow_alias=deploy_meta.get("flow_alias"),
                 cron_offset=deploy_meta.get("cron_offset", 0),
                 work_pool_name=deploy_meta.get("work_pool_name"),
-                triggers=deploy_meta.get("triggers"),
+                triggers=triggers,
                 emit_events=emit_events,
             )
         )

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -22,22 +22,22 @@ DEFAULT_DEPLOYMENT_WRAPPER_ENTRYPOINT = "echodataflow/flows/flows_helper.py:flow
 
 @dataclass(frozen=True)
 class DeploymentSpec:
-    flow_key: str
-    deployment_name: str
-    flow_module: str
-    flow_name: str
-    flow_obj: Flow[..., Any] | None = None
-    flow_alias: str | None = None
-    cron_offset: int = 0
-    work_pool_name: str | None = None
-    triggers: list[dict[str, Any]] | None = None
-    emit_events: list[str] | None = None
+    flow_key: str  # the flow key from deploy config, used to look up flow params and deploy settings
+    deployment_name: str  # the deployment name to use for this flow
+    flow_module: str  # the module name as string
+    flow_name: str  # the flow function name including flow_ prefix
+    flow_obj: Flow[..., Any] | None = None  # the actual Flow object, resolved from flow_module and flow_name
+    flow_alias: str | None = None  # an optional alias for the flow, used for deployment naming
+    cron_offset: int = 0  # the cron offset in minutes, used to stagger deployments
+    work_pool_name: str | None = None  # the work pool name to use for this deployment, if different from default
+    triggers: list[dict[str, Any]] | None = None  # a list of trigger definitions, each with 'expect' and 'resource_name' keys
+    emit_events: list[str] | None = None  # a list of event names to emit after the flow completes, used for triggering downstream flows
 
 
 def discover_all_flows() -> dict[str, dict[str, Any]]:
     """
     Discover all flow_* functions from all modules in echodataflow.flows folder.
-    Returns mapping: flow_name -> {"flow_obj", "flow_function_name", "flow_module"}
+    Returns mapping: flow_name -> {"flow_obj", "module_name", "flow_function_name"}
     """
 
     flows_pkg_spec = importlib.util.find_spec("echodataflow.flows") # this points to __init__.py
@@ -67,8 +67,8 @@ def discover_all_flows() -> dict[str, dict[str, Any]]:
             flow_obj = cast(Flow[..., Any], getattr(flow_module, flow_function_name))
             
             discovered[flow_name] = {
+                "module_name": module_name,  # the module name as string
                 "flow_function_name": flow_function_name,  # flow function name including flow_ prefix
-                "flow_module": flow_module,  # the actual module object, useful for concurrency setup
                 "flow_obj": flow_obj,  # the actual Flow object
             }
     
@@ -426,7 +426,7 @@ def build_deploy_specs(
             DeploymentSpec(
                 flow_key=key,
                 deployment_name=deploy_meta.get("deployment_name", key),
-                flow_module=flow_info["flow_module"].__name__.split(".")[-1],
+                flow_module=flow_info["module_name"],
                 flow_name=flow_info["flow_function_name"],
                 flow_obj=flow_info["flow_obj"],
                 flow_alias=deploy_meta.get("flow_alias"),

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -25,8 +25,8 @@ class DeploymentSpec:
     flow_key: str
     deployment_name: str
     entrypoint: str
-    target_flow_module: str
-    target_flow_name: str
+    flow_module: str
+    flow_name: str
     flow_obj: Flow[..., Any] | None = None
     flow_alias: str | None = None
     cron_offset: int = 0
@@ -38,7 +38,7 @@ class DeploymentSpec:
 def discover_all_flows() -> dict[str, dict[str, Any]]:
     """
     Discover all flow_* functions from all modules in echodataflow.flows folder.
-    Returns mapping: flow_name -> {"flow_obj", "module_name", "flow_attr_name", "entrypoint", "flow_module"}
+    Returns mapping: flow_name -> {"flow_obj", "module_name", "flow_function_name", "entrypoint", "flow_module"}
     """
 
     flows_pkg_spec = importlib.util.find_spec("echodataflow.flows") # this points to __init__.py
@@ -60,17 +60,17 @@ def discover_all_flows() -> dict[str, dict[str, Any]]:
             raise ImportError(f"Failed to import echodataflow.flows.{module_name}: {e}")
         
         # Find all flow_* attributes in the module
-        for flow_attr_name in dir(flow_module):
-            if not flow_attr_name.startswith("flow_"):
+        for flow_function_name in dir(flow_module):
+            if not flow_function_name.startswith("flow_"):
                 continue
 
-            flow_name = flow_attr_name.removeprefix("flow_")
-            flow_obj = cast(Flow[..., Any], getattr(flow_module, flow_attr_name))
-            entrypoint = f"{DEFAULT_ENTRYPOINT_ROOT}/{module_name}.py:{flow_attr_name}"
+            flow_name = flow_function_name.removeprefix("flow_")
+            flow_obj = cast(Flow[..., Any], getattr(flow_module, flow_function_name))
+            entrypoint = f"{DEFAULT_ENTRYPOINT_ROOT}/{module_name}.py:{flow_function_name}"
             
             discovered[flow_name] = {
                 "module_name": module_name,  # the module name as string
-                "flow_attr_name": flow_attr_name,  # flow function name including flow_ prefix
+                "flow_function_name": flow_function_name,  # flow function name including flow_ prefix
                 "flow_module": flow_module,  # the actual module object, useful for concurrency setup
                 "flow_obj": flow_obj,  # the actual Flow object
                 "entrypoint": entrypoint,  # the entrypoint string for deployment
@@ -430,8 +430,8 @@ def build_deploy_specs(
                 flow_key=key,
                 deployment_name=deploy_meta.get("deployment_name", key),
                 entrypoint=flow_info["entrypoint"],
-                target_flow_module=flow_info["module_name"],
-                target_flow_name=flow_info["flow_attr_name"],
+                flow_module=flow_info["module_name"],
+                flow_name=flow_info["flow_function_name"],
                 flow_obj=flow_info["flow_obj"],
                 flow_alias=deploy_meta.get("flow_alias"),
                 cron_offset=deploy_meta.get("cron_offset", 0),
@@ -475,8 +475,8 @@ def create_deployments(
 
         # If emit_events is configured, run the generic wrapper flow instead.
         if spec.emit_events is not None:
-            deployment_kwargs["parameters"]["flow_module"] = spec.target_flow_module
-            deployment_kwargs["parameters"]["flow_name"] = spec.target_flow_name
+            deployment_kwargs["parameters"]["flow_module"] = spec.flow_module
+            deployment_kwargs["parameters"]["flow_name"] = spec.flow_name
             deployment_kwargs["parameters"]["emit_events"] = spec.emit_events
             spec_entrypoint = DEFAULT_EMIT_EVENTS_ENTRYPOINT
         else:

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -17,15 +17,14 @@ from yaml import safe_load
 
 from echodataflow.deployment.core import DEFAULT_ENTRYPOINT_ROOT
 
-DEFAULT_DEPLOYMENT_WRAPPER_ENTRYPOINT = "echodataflow/flows/flows_helper.py:flow_deployment_wrapper"
-
 
 @dataclass(frozen=True)
 class DeploymentSpec:
     flow_key: str  # the flow key from deploy config, used to look up flow params and deploy settings
     deployment_name: str  # the deployment name to use for this flow
     flow_obj: Flow[..., Any]  # the actual Flow object resolved from discovered flow metadata
-    parameters: dict[str, Any]  # fully compiled deployment parameters passed to the wrapper
+    entrypoint: str  # source-relative entrypoint for the actual deployed flow
+    parameters: dict[str, Any]  # parameters passed directly to the deployed flow
     cron: str | None = None  # precomputed cron schedule, when interval mode is used
     work_pool_name: str | None = None  # the work pool name to use for this deployment, if different from default
     triggers: list[Any] | None = None  # precomputed Prefect trigger objects
@@ -243,6 +242,7 @@ def build_triggers(trigger_items: list[dict[str, Any]]) -> list[Any]:
             expect={item["expect"]},
             match_related={
                 "prefect.resource.name": item["resource_name"],
+                "prefect.resource.role": "deployment",
             },
         )
         for item in trigger_items
@@ -312,40 +312,6 @@ def validate_triggers(
         )
 
     return validated_triggers
-
-
-def validate_emit_events(
-    emit_events: Any,
-    *,
-    flow_key: str,
-) -> list[str] | None:
-    """
-    Validate emitted event names from deploy config.
-
-    When configured, emit_events must be a non-empty list of non-empty strings.
-    """
-    emit_events = validate_optional_non_empty_list(
-        emit_events,
-        field_name=f"deploy_cfg.flows.{flow_key}.emit_events",
-        item_label="event name",
-    )
-    if emit_events is None:
-        return None
-
-    validated_events: list[str] = []
-    for event_name in emit_events:
-        if not isinstance(event_name, str):
-            raise ValueError(
-                f"deploy_cfg.flows.{flow_key}.emit_events entries must be strings"
-            )
-        event_name = event_name.strip()
-        if not event_name:
-            raise ValueError(
-                f"deploy_cfg.flows.{flow_key}.emit_events entries must be non-empty"
-            )
-        validated_events.append(event_name)
-
-    return validated_events
 
 
 def validate_flow_coverage(
@@ -463,22 +429,15 @@ def build_deploy_specs(
         if key in time_offset_targets:
             deployment_parameters["time_offset_seconds"] = time_offset_seconds
 
-        deployment_parameters["flow_module"] = flow_info["flow_module"]
-        deployment_parameters["flow_name"] = flow_info["flow_function_name"]
-
-        # Add emit_events if configured in deploy config
-        emit_events = validate_emit_events(
-            deploy_meta.get("emit_events"),
-            flow_key=key,
-        )
-        if emit_events is not None:
-            deployment_parameters["emit_events"] = emit_events
-
         specs.append(
             DeploymentSpec(
                 flow_key=key,
                 deployment_name=deploy_meta.get("deployment_name", key),
                 flow_obj=flow_info["flow_obj"],
+                entrypoint=(
+                    f"{DEFAULT_ENTRYPOINT_ROOT}/{flow_info['flow_module']}.py:"
+                    f"{flow_info['flow_function_name']}"
+                ),
                 parameters=deployment_parameters,
                 cron=cron,
                 work_pool_name=deploy_meta.get("work_pool_name"),
@@ -521,7 +480,7 @@ def create_deployments(
         deployment = (
             flow_obj.from_source(
                 source=source,
-                entrypoint=DEFAULT_DEPLOYMENT_WRAPPER_ENTRYPOINT,
+                entrypoint=spec.entrypoint,
             ).to_deployment(**deployment_kwargs)
         )
 

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -37,7 +37,7 @@ class DeploymentSpec:
 def discover_all_flows() -> dict[str, dict[str, Any]]:
     """
     Discover all flow_* functions from all modules in echodataflow.flows folder.
-    Returns mapping: flow_name -> {"flow_obj", "module_name", "flow_function_name", "entrypoint", "flow_module"}
+    Returns mapping: flow_name -> {"flow_obj", "flow_function_name", "flow_module"}
     """
 
     flows_pkg_spec = importlib.util.find_spec("echodataflow.flows") # this points to __init__.py
@@ -65,14 +65,11 @@ def discover_all_flows() -> dict[str, dict[str, Any]]:
 
             flow_name = flow_function_name.removeprefix("flow_")
             flow_obj = cast(Flow[..., Any], getattr(flow_module, flow_function_name))
-            entrypoint = f"{DEFAULT_ENTRYPOINT_ROOT}/{module_name}.py:{flow_function_name}"
             
             discovered[flow_name] = {
-                "module_name": module_name,  # the module name as string
                 "flow_function_name": flow_function_name,  # flow function name including flow_ prefix
                 "flow_module": flow_module,  # the actual module object, useful for concurrency setup
                 "flow_obj": flow_obj,  # the actual Flow object
-                "entrypoint": entrypoint,  # the entrypoint string for deployment
             }
     
     return discovered
@@ -429,7 +426,7 @@ def build_deploy_specs(
             DeploymentSpec(
                 flow_key=key,
                 deployment_name=deploy_meta.get("deployment_name", key),
-                flow_module=flow_info["module_name"],
+                flow_module=flow_info["flow_module"].__name__.split(".")[-1],
                 flow_name=flow_info["flow_function_name"],
                 flow_obj=flow_info["flow_obj"],
                 flow_alias=deploy_meta.get("flow_alias"),

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -37,7 +37,7 @@ class DeploymentSpec:
 def discover_all_flows() -> dict[str, dict[str, Any]]:
     """
     Discover all flow_* functions from all modules in echodataflow.flows folder.
-    Returns mapping: flow_name -> {"flow_obj", "module_name", "flow_function_name"}
+    Returns mapping: flow_name -> {"flow_obj", "flow_module", "flow_function_name"}
     """
 
     flows_pkg_spec = importlib.util.find_spec("echodataflow.flows") # this points to __init__.py
@@ -67,7 +67,7 @@ def discover_all_flows() -> dict[str, dict[str, Any]]:
             flow_obj = cast(Flow[..., Any], getattr(flow_module, flow_function_name))
             
             discovered[flow_name] = {
-                "module_name": module_name,  # the module name as string
+                "flow_module": module_name,  # the module name as string
                 "flow_function_name": flow_function_name,  # flow function name including flow_ prefix
                 "flow_obj": flow_obj,  # the actual Flow object
             }
@@ -426,7 +426,7 @@ def build_deploy_specs(
             DeploymentSpec(
                 flow_key=key,
                 deployment_name=deploy_meta.get("deployment_name", key),
-                flow_module=flow_info["module_name"],
+                flow_module=flow_info["flow_module"],
                 flow_name=flow_info["flow_function_name"],
                 flow_obj=flow_info["flow_obj"],
                 flow_alias=deploy_meta.get("flow_alias"),

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -17,12 +17,16 @@ from yaml import safe_load
 
 from echodataflow.deployment.core import DEFAULT_ENTRYPOINT_ROOT
 
+DEFAULT_EMIT_EVENTS_ENTRYPOINT = "echodataflow/flows/flows_helper.py:flow_emit_events_wrapper"
+
 
 @dataclass(frozen=True)
 class DeploymentSpec:
     flow_key: str
     deployment_name: str
     entrypoint: str
+    target_flow_module: str
+    target_flow_name: str
     flow_obj: Flow[..., Any] | None = None
     flow_alias: str | None = None
     cron_offset: int = 0
@@ -35,10 +39,9 @@ class DeploymentSpec:
 def discover_all_flows() -> dict[str, dict[str, Any]]:
     """
     Discover all flow_* functions from all modules in echodataflow.flows folder.
-    Returns mapping: flow_name -> {"flow_obj", "module_name", "entrypoint"}
+    Returns mapping: flow_name -> {"flow_obj", "module_name", "flow_attr_name", "entrypoint", "flow_module"}
     """
-    import os
-    
+
     flows_pkg_spec = importlib.util.find_spec("echodataflow.flows") # this points to __init__.py
     if flows_pkg_spec is None or flows_pkg_spec.origin is None:
         raise ValueError("Could not locate echodataflow.flows package")
@@ -58,41 +61,46 @@ def discover_all_flows() -> dict[str, dict[str, Any]]:
             raise ImportError(f"Failed to import echodataflow.flows.{module_name}: {e}")
         
         # Find all flow_* attributes in the module
-        for attr_name in dir(flow_module):
-            if not attr_name.startswith("flow_"):
+        for flow_attr_name in dir(flow_module):
+            if not flow_attr_name.startswith("flow_"):
                 continue
-            
-            flow_name = attr_name.removeprefix("flow_")
-            flow_obj = cast(Flow[..., Any], getattr(flow_module, attr_name))
-            entrypoint = f"{DEFAULT_ENTRYPOINT_ROOT}/{module_name}.py:{attr_name}"
+
+            flow_name = flow_attr_name.removeprefix("flow_")
+            flow_obj = cast(Flow[..., Any], getattr(flow_module, flow_attr_name))
+            entrypoint = f"{DEFAULT_ENTRYPOINT_ROOT}/{module_name}.py:{flow_attr_name}"
             
             discovered[flow_name] = {
-                "flow_obj": flow_obj,
-                "module_name": module_name,
-                "flow_module": flow_module,
-                "entrypoint": entrypoint,
+                "module_name": module_name,  # the module name as string
+                "flow_attr_name": flow_attr_name,  # flow function name including flow_ prefix
+                "flow_module": flow_module,  # the actual module object, useful for concurrency setup
+                "flow_obj": flow_obj,  # the actual Flow object
+                "entrypoint": entrypoint,  # the entrypoint string for deployment
             }
     
     return discovered
 
 
-def filter_flows_for_deploy(all_flows: dict[str, dict[str, Any]], deploy_cfg: dict[str, Any]) -> dict[str, dict[str, Any]]:
+def filter_flows_for_deploy(
+    all_flows: dict[str, dict[str, Any]],
+    deploy_cfg: dict[str, Any]
+) -> dict[str, dict[str, Any]]:
     """
     Filter discovered flows to only those specified in deploy config.
     Build a flow-name mapping keyed by `flow_<name>` from discovered flows,
-    then resolve deploy entries by `flow_<flow_key>` or `flow_<flow_alias>`.
-    Returns mapping keyed by deploy flow_key to discovered flow metadata.
+    then resolve deploy entries by `flow_<key>` or `flow_<alias>`.
+    Returns mapping keyed by deploy flow_<key> to discovered flow info.
     """
     filtered: dict[str, dict[str, Any]] = {}
     flow_name_map = {f"flow_{name}": flow_info for name, flow_info in all_flows.items()}
     
-    for flow_key, deploy_meta in deploy_cfg.get("flows", {}).items():
-        requested_name = f"flow_{flow_key}"
+    for key, deploy_meta in deploy_cfg.get("flows", {}).items():
+        requested_name = f"flow_{key}"  # flow function name: 
+                                             # either flow_<key> or flow_<alias>
         alias_name: str | None = None
         if isinstance(deploy_meta, dict):
-            flow_alias = deploy_meta.get("flow_alias")
-            if isinstance(flow_alias, str) and flow_alias:
-                alias_name = f"flow_{flow_alias}"
+            alias = deploy_meta.get("flow_alias")
+            if isinstance(alias, str) and alias:
+                alias_name = f"flow_{alias}"
 
         matched_name = requested_name
         if matched_name not in flow_name_map and alias_name is not None:
@@ -101,12 +109,12 @@ def filter_flows_for_deploy(all_flows: dict[str, dict[str, Any]], deploy_cfg: di
         if matched_name not in flow_name_map:
             available = ", ".join(sorted(flow_name_map)) or "<none>"
             raise KeyError(
-                f"Flow '{flow_key}' not found in discovered flows "
+                f"Flow '{key}' not found in discovered flows "
                 f"(checked {requested_name!r}"
                 f"{f' and {alias_name!r}' if alias_name else ''}). "
                 f"Available flows: {available}"
             )
-        filtered[flow_key] = flow_name_map[matched_name]
+        filtered[key] = flow_name_map[matched_name]
     
     return filtered
 
@@ -116,7 +124,7 @@ def load_config(config_path: Path) -> dict[str, Any]:
         return safe_load(file)
 
 
-def _default_local_source_root() -> Path:
+def _infer_local_source_root() -> Path:
     """Infer local source root from installed echodataflow package location."""
     spec = importlib.util.find_spec("echodataflow")
     if spec is None:
@@ -179,7 +187,7 @@ def resolve_deployment_source(
         source_mode_origin = "default:local"
 
     if mode == "local":
-        default_local_dir = _validate_local_source_layout(_default_local_source_root())
+        default_local_dir = _validate_local_source_layout(_infer_local_source_root())
         source = str(default_local_dir)
         if log_context:
             print(
@@ -231,13 +239,6 @@ def _compute_time_offset_seconds(flow_start_time: str | None) -> float:
         - datetime.datetime.fromisoformat(flow_start_time).astimezone(datetime.timezone.utc)
     )
     return curr_time_offset.total_seconds()
-
-
-def set_prefect_variables(
-    deploy_cfg: dict[str, Any],
-) -> None:
-    """Set Prefect Variables from deploy specifications."""
-    Variable.set("flow_start_time", deploy_cfg.get("flow_start_time"), overwrite=True)
 
 
 def build_cron(interval: int | None, cron_offset: int = 0) -> str | None:
@@ -343,25 +344,33 @@ def build_deploy_specs(
     """
     specs: list[DeploymentSpec] = []
 
-    for flow_key, deploy_meta in deploy_cfg.get("flows", {}).items():
+    for key, deploy_meta in deploy_cfg.get("flows", {}).items():
         if not isinstance(deploy_meta, dict):
             continue
 
-        if flow_key not in filtered_flows:
+        if key not in filtered_flows:
             continue
 
-        flow_info = filtered_flows[flow_key]
-        entrypoint = deploy_meta.get("entrypoint") or flow_info["entrypoint"]
+        # Disallow specifying entrypoint in deploy config
+        if "entrypoint" in deploy_meta:
+            raise ValueError(
+                f"deploy_cfg.flows.{key}.entrypoint is not supported; "
+                "entrypoint is discovered from the flow module"
+            )
+
+        flow_info = filtered_flows[key]
         emit_events = validate_emit_events(
             deploy_meta.get("emit_events"),
-            flow_key=flow_key,
+            flow_key=key,
         )
 
         specs.append(
             DeploymentSpec(
-                flow_key=flow_key,
-                deployment_name=deploy_meta.get("deployment_name", flow_key),
-                entrypoint=entrypoint,
+                flow_key=key,
+                deployment_name=deploy_meta.get("deployment_name", key),
+                entrypoint=flow_info["entrypoint"],
+                target_flow_module=flow_info["module_name"],
+                target_flow_name=flow_info["flow_attr_name"],
                 flow_obj=flow_info["flow_obj"],
                 flow_alias=deploy_meta.get("flow_alias"),
                 cron_offset=deploy_meta.get("cron_offset", 0),
@@ -403,10 +412,17 @@ def create_deployments(
         if spec.flow_key in time_offset_targets:
             deployment_kwargs["parameters"]["time_offset_seconds"] = time_offset_seconds
 
-        # Inject emitted event names into flow parameters when configured.
+        # If emit_events is configured, run the generic wrapper flow instead.
         if spec.emit_events is not None:
+            deployment_kwargs["parameters"]["flow_module"] = spec.target_flow_module
+            deployment_kwargs["parameters"]["flow_name"] = spec.target_flow_name
             deployment_kwargs["parameters"]["emit_events"] = spec.emit_events
+            spec_entrypoint = DEFAULT_EMIT_EVENTS_ENTRYPOINT
+        else:
+            spec_entrypoint = spec.entrypoint
 
+        # Build triggers or cron schedule for the deployment
+        # TODO: raise error if both triggers and cron are specified in deploy config
         if spec.triggers is not None:
             deployment_kwargs["triggers"] = build_triggers(spec.triggers)
         else:
@@ -421,7 +437,7 @@ def create_deployments(
         deployment = (
             flow_obj.from_source(
                 source=source,
-                entrypoint=spec.entrypoint,
+                entrypoint=spec_entrypoint,
             ).to_deployment(**deployment_kwargs)
         )
 

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -29,6 +29,7 @@ class DeploymentSpec:
     apply_separately: bool = False
     work_pool_name: str | None = None
     triggers: list[dict[str, Any]] | None = None
+    emit_events: list[str] | None = None
 
 
 def discover_all_flows() -> dict[str, dict[str, Any]]:
@@ -264,6 +265,44 @@ def build_triggers(trigger_items: list[dict[str, Any]]) -> list[Any]:
     ]
 
 
+def validate_emit_events(
+    emit_events: Any,
+    *,
+    flow_key: str,
+) -> list[str] | None:
+    """
+    Validate emitted event names from deploy config.
+
+    When configured, emit_events must be a non-empty list of non-empty strings.
+    """
+    if emit_events is None:
+        return None
+
+    if not isinstance(emit_events, list):
+        raise ValueError(
+            f"deploy_cfg.flows.{flow_key}.emit_events must be a list of event names"
+        )
+    if len(emit_events) == 0:
+        raise ValueError(
+            f"deploy_cfg.flows.{flow_key}.emit_events must contain at least one event name"
+        )
+
+    sanitized_events: list[str] = []
+    for event_name in emit_events:
+        if not isinstance(event_name, str):
+            raise ValueError(
+                f"deploy_cfg.flows.{flow_key}.emit_events entries must be strings"
+            )
+        event_name = event_name.strip()
+        if not event_name:
+            raise ValueError(
+                f"deploy_cfg.flows.{flow_key}.emit_events entries must be non-empty"
+            )
+        sanitized_events.append(event_name)
+
+    return sanitized_events
+
+
 def validate_flow_coverage(
     param_cfg: dict[str, Any],
     deploy_cfg: dict[str, Any],
@@ -313,6 +352,10 @@ def build_deploy_specs(
 
         flow_info = filtered_flows[flow_key]
         entrypoint = deploy_meta.get("entrypoint") or flow_info["entrypoint"]
+        emit_events = validate_emit_events(
+            deploy_meta.get("emit_events"),
+            flow_key=flow_key,
+        )
 
         specs.append(
             DeploymentSpec(
@@ -325,6 +368,7 @@ def build_deploy_specs(
                 apply_separately=deploy_meta.get("apply_separately", False),
                 work_pool_name=deploy_meta.get("work_pool_name"),
                 triggers=deploy_meta.get("triggers"),
+                emit_events=emit_events,
             )
         )
 
@@ -358,6 +402,10 @@ def create_deployments(
         # Inject time_offset_seconds if this flow is marked for it
         if spec.flow_key in time_offset_targets:
             deployment_kwargs["parameters"]["time_offset_seconds"] = time_offset_seconds
+
+        # Inject emitted event names into flow parameters when configured.
+        if spec.emit_events is not None:
+            deployment_kwargs["parameters"]["emit_events"] = spec.emit_events
 
         if spec.triggers is not None:
             deployment_kwargs["triggers"] = build_triggers(spec.triggers)

--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -21,7 +21,6 @@ from botocore.config import Config
 
 from prefect import flow, task, get_run_logger, get_client
 from prefect_dask import DaskTaskRunner
-from prefect.exceptions import ObjectAlreadyExists, ObjectNotFound
 from prefect.states import Cancelled, Failed
 from prefect import runtime
 from prefect.variables import Variable
@@ -37,19 +36,6 @@ from segmentation_inference.model import binary_hake_model
 from segmentation_inference.utils import get_MVBS_tensor
 
 import torch
-
-
-
-async def set_concurrency_limit():
-    async with get_client() as client:
-        try:
-            await client.read_concurrency_limit_by_tag("raw2Sv")
-        except ObjectNotFound:
-            try:
-                await client.create_concurrency_limit(tag="raw2Sv", concurrency_limit=4)
-            except ObjectAlreadyExists:
-                pass
-
 
 # Turn on verbose logging for echopype
 # otherwise all logging will be muted

--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -234,7 +234,6 @@ def flow_raw2Sv(
 
 @task(
     log_prints=True,
-    tags=["raw2Sv"],
 )
 def task_raw2Sv(
     raw_path: str,
@@ -314,7 +313,6 @@ async def flow_create_MVBS(
     """
     logger = get_run_logger()
 
-    # with concurrency("create_MVBS", occupy=1):
     # Set end_time to current time - time_offset_seconds
     end_time = round_up_mins(
         datetime.datetime.now() - datetime.timedelta(seconds=time_offset_seconds),

--- a/src/echodataflow/flows/flows_biology.py
+++ b/src/echodataflow/flows/flows_biology.py
@@ -195,6 +195,7 @@ def flow_ingest_haul(
     file_length_all: str = "length_all.csv",
     file_length_count_all: str = "length_count_all.csv",
     file_stratum_mean: str = "stratum_mean.csv",
+    emit_events: list[str] | None = None,
 ):
 
     # Assemble full paths
@@ -348,8 +349,10 @@ def flow_ingest_haul(
         )
         df_stratum.to_csv(file_stratum_mean)
 
-        # Emit custom event when new hauls are processed
-        emit_event(
-            event="haul.ingested",
-            resource={"prefect.resource.id": "ingest_haul"}
-        )
+        # Emit one or more custom events when new hauls are processed.
+        emit_events = emit_events or ["haul.ingested"]
+        for event_name in emit_events:
+            emit_event(
+                event=event_name,
+                resource={"prefect.resource.id": "ingest_haul"}
+            )

--- a/src/echodataflow/flows/flows_biology.py
+++ b/src/echodataflow/flows/flows_biology.py
@@ -8,7 +8,6 @@ import configparser, s3fs
 from echodataflow.utils.const import TS_L_PARAMS, INFO_DATAFRAME_MAPPING
 
 from prefect import task, flow
-from prefect.events import emit_event
 
 
 # Set up paths
@@ -195,7 +194,6 @@ def flow_ingest_haul(
     file_length_all: str = "length_all.csv",
     file_length_count_all: str = "length_count_all.csv",
     file_stratum_mean: str = "stratum_mean.csv",
-    emit_events: list[str] | None = None,
 ):
 
     # Assemble full paths
@@ -349,10 +347,3 @@ def flow_ingest_haul(
         )
         df_stratum.to_csv(file_stratum_mean)
 
-        # Emit one or more custom events when new hauls are processed.
-        emit_events = emit_events or ["haul.ingested"]
-        for event_name in emit_events:
-            emit_event(
-                event=event_name,
-                resource={"prefect.resource.id": "ingest_haul"}
-            )

--- a/src/echodataflow/flows/flows_helper.py
+++ b/src/echodataflow/flows/flows_helper.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 import datetime
 import asyncio
-import importlib
 import re
 
 import pandas as pd
@@ -13,7 +12,6 @@ from botocore.config import Config
 from prefect import flow, task, get_client, runtime
 from prefect import runtime
 from prefect.client.schemas.filters import FlowRunFilter
-from prefect.events import emit_event
 from prefect.states import Cancelled
 from prefect.variables import Variable
 
@@ -108,29 +106,6 @@ def _iter_s3_keys(s3_client, s3_bucket: str, prefix: str):
     for page in paginator.paginate(Bucket=s3_bucket, Prefix=prefix):
         for obj in page.get("Contents", []):
             yield obj["Key"]
-
-
-@flow(log_prints=True)
-def flow_deployment_wrapper(
-    flow_module: str,
-    flow_name: str,
-    emit_events: list[str] | None = None,
-    **flow_kwargs,
-):
-    """Run a target flow and apply optional deployment-level behavior."""
-    module = importlib.import_module(f"echodataflow.flows.{flow_module}")
-    flow_fn = getattr(module, flow_name)
-    result = flow_fn(**flow_kwargs)
-
-    if emit_events:
-        resource_name = flow_name.removeprefix("flow_")
-        for event_name in emit_events:
-            emit_event(
-                event=event_name,
-                resource={"prefect.resource.id": resource_name},
-            )
-
-    return result
 
 
 @flow(log_prints=True)

--- a/src/echodataflow/flows/flows_helper.py
+++ b/src/echodataflow/flows/flows_helper.py
@@ -111,13 +111,13 @@ def _iter_s3_keys(s3_client, s3_bucket: str, prefix: str):
 
 
 @flow(log_prints=True)
-def flow_emit_events_wrapper(
+def flow_deployment_wrapper(
     flow_module: str,
     flow_name: str,
     emit_events: list[str] | None = None,
     **flow_kwargs,
 ):
-    """Run a flow and emit configured events after it succeeds."""
+    """Run a target flow and apply optional deployment-level behavior."""
     module = importlib.import_module(f"echodataflow.flows.{flow_module}")
     flow_fn = getattr(module, flow_name)
     result = flow_fn(**flow_kwargs)

--- a/src/echodataflow/flows/flows_helper.py
+++ b/src/echodataflow/flows/flows_helper.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import datetime
 import asyncio
+import importlib
 import re
 
 import pandas as pd
@@ -12,6 +13,7 @@ from botocore.config import Config
 from prefect import flow, task, get_client, runtime
 from prefect import runtime
 from prefect.client.schemas.filters import FlowRunFilter
+from prefect.events import emit_event
 from prefect.states import Cancelled
 from prefect.variables import Variable
 
@@ -106,6 +108,29 @@ def _iter_s3_keys(s3_client, s3_bucket: str, prefix: str):
     for page in paginator.paginate(Bucket=s3_bucket, Prefix=prefix):
         for obj in page.get("Contents", []):
             yield obj["Key"]
+
+
+@flow(log_prints=True)
+def flow_emit_events_wrapper(
+    flow_module: str,
+    flow_name: str,
+    emit_events: list[str] | None = None,
+    **flow_kwargs,
+):
+    """Run a flow and emit configured events after it succeeds."""
+    module = importlib.import_module(f"echodataflow.flows.{flow_module}")
+    flow_fn = getattr(module, flow_name)
+    result = flow_fn(**flow_kwargs)
+
+    if emit_events:
+        resource_name = flow_name.removeprefix("flow_")
+        for event_name in emit_events:
+            emit_event(
+                event=event_name,
+                resource={"prefect.resource.id": resource_name},
+            )
+
+    return result
 
 
 @flow(log_prints=True)

--- a/src/echodataflow/flows/flows_integration.py
+++ b/src/echodataflow/flows/flows_integration.py
@@ -133,6 +133,7 @@ def flow_ingest_NASC(
     file_NASC_all_grid: str = "NASC_all_griddify.geojson",
     num_NASC_reprocess: int = 1,
     new_file_num_limit: int = 50,
+    emit_events: list[str] | None = None,
 ):
     """
     Ingest NASC data from zarr files and combine into a single DataFrame.
@@ -257,11 +258,13 @@ def flow_ingest_NASC(
         )
         gdf_NASC.to_file(Path(path_vm_local) / file_NASC_all_grid, driver="GeoJSON")
 
-        # Emit custom event when new NASC files are processed
-        emit_event(
-            event="nasc.ingested",
-            resource={"prefect.resource.id": "ingest_NASC"}
-        )
+        # Emit one or more custom events when new NASC files are processed.
+        emit_events = emit_events or ["nasc.ingested"]
+        for event_name in emit_events:
+            emit_event(
+                event=event_name,
+                resource={"prefect.resource.id": "ingest_NASC"}
+            )
 
         # TODO: add error handling
 

--- a/src/echodataflow/flows/flows_integration.py
+++ b/src/echodataflow/flows/flows_integration.py
@@ -15,7 +15,6 @@ from echodataflow.utils.grid import create_boundary_gdf, create_grid_from_bounds
 from echodataflow.flows.flows_biology import add_stratum
 
 from prefect import task, flow, get_run_logger
-from prefect.events import emit_event
 
 
 # Turn on verbose logging for echopype
@@ -133,7 +132,6 @@ def flow_ingest_NASC(
     file_NASC_all_grid: str = "NASC_all_griddify.geojson",
     num_NASC_reprocess: int = 1,
     new_file_num_limit: int = 50,
-    emit_events: list[str] | None = None,
 ):
     """
     Ingest NASC data from zarr files and combine into a single DataFrame.
@@ -258,13 +256,6 @@ def flow_ingest_NASC(
         )
         gdf_NASC.to_file(Path(path_vm_local) / file_NASC_all_grid, driver="GeoJSON")
 
-        # Emit one or more custom events when new NASC files are processed.
-        emit_events = emit_events or ["nasc.ingested"]
-        for event_name in emit_events:
-            emit_event(
-                event=event_name,
-                resource={"prefect.resource.id": "ingest_NASC"}
-            )
 
         # TODO: add error handling
 

--- a/tests/deployment/test_deploy_cli.py
+++ b/tests/deployment/test_deploy_cli.py
@@ -2,9 +2,6 @@ import importlib.util
 import sys
 from pathlib import Path
 
-import pytest
-
-
 def import_module_from_path(module_name, file_path):
     spec = importlib.util.spec_from_file_location(module_name, file_path)
     module = importlib.util.module_from_spec(spec)
@@ -19,7 +16,7 @@ def _load_deploy_cli_module(install_prefect_stubs):
     return import_module_from_path("deploy_cli_test_mod", module_path)
 
 
-def test_build_parser_run_boolean_optional(install_prefect_stubs):
+def test_build_parser_run(install_prefect_stubs):
     module = _load_deploy_cli_module(install_prefect_stubs=install_prefect_stubs)
 
     parser = module._build_parser()
@@ -32,12 +29,10 @@ def test_build_parser_run_boolean_optional(install_prefect_stubs):
             "config_ship.yaml",
             "--deploy-spec",
             "deploy_ship.yaml",
-            "--no-use-concurrency",
         ]
     )
 
     assert args.target == "run"
-    assert args.use_concurrency is False
     assert args.param_config == Path("config_ship.yaml")
     assert args.deploy_spec == Path("deploy_ship.yaml")
 
@@ -63,7 +58,6 @@ def test_main_dispatches_run_args(monkeypatch, install_prefect_stubs):
             "recipe/params/config_ship.yaml",
             "--deploy-spec",
             "recipe/deploy/deploy_ship.yaml",
-            "--no-use-concurrency",
         ],
     )
 
@@ -71,24 +65,3 @@ def test_main_dispatches_run_args(monkeypatch, install_prefect_stubs):
 
     assert captured["param_cfg_path"] == Path("recipe/params/config_ship.yaml")
     assert captured["deploy_cfg_path"] == Path("recipe/deploy/deploy_ship.yaml")
-    assert captured["run_concurrency_setup"] is False
-
-
-def test_run_concurrency_setup_rejects_conflicting_tag_limits(monkeypatch, install_prefect_stubs):
-    module = _load_deploy_cli_module(install_prefect_stubs=install_prefect_stubs)
-
-    deploy_cfg = {
-        "flows": {
-            "raw2Sv": {
-                "concurrency_limit": 4,
-                "concurrency_tag": "shared-tag",
-            },
-            "predict_hake": {
-                "concurrency_limit": 2,
-                "concurrency_tag": "shared-tag",
-            },
-        }
-    }
-
-    with pytest.raises(ValueError, match="Conflicting concurrency_limit"):
-        module._run_concurrency_setup(deploy_cfg)

--- a/tests/deployment/test_deploy_cli.py
+++ b/tests/deployment/test_deploy_cli.py
@@ -1,8 +1,6 @@
 import importlib.util
-import os
 import sys
 from pathlib import Path
-from unittest.mock import call
 
 import pytest
 
@@ -40,7 +38,6 @@ def test_build_parser_run_boolean_optional(install_prefect_stubs):
 
     assert args.target == "run"
     assert args.use_concurrency is False
-    assert args.source_mode is None
     assert args.param_config == Path("config_ship.yaml")
     assert args.deploy_spec == Path("deploy_ship.yaml")
 
@@ -66,16 +63,32 @@ def test_main_dispatches_run_args(monkeypatch, install_prefect_stubs):
             "recipe/params/config_ship.yaml",
             "--deploy-spec",
             "recipe/deploy/deploy_ship.yaml",
-            "--source-mode",
-            "git",
             "--no-use-concurrency",
         ],
     )
 
     module.main()
 
-    assert os.environ["PREFECT_SOURCE_MODE"] == "git"
     assert captured["param_cfg_path"] == Path("recipe/params/config_ship.yaml")
     assert captured["deploy_cfg_path"] == Path("recipe/deploy/deploy_ship.yaml")
-    assert captured["source_mode"] == "git"
     assert captured["run_concurrency_setup"] is False
+
+
+def test_run_concurrency_setup_rejects_conflicting_tag_limits(monkeypatch, install_prefect_stubs):
+    module = _load_deploy_cli_module(install_prefect_stubs=install_prefect_stubs)
+
+    deploy_cfg = {
+        "flows": {
+            "raw2Sv": {
+                "concurrency_limit": 4,
+                "concurrency_tag": "shared-tag",
+            },
+            "predict_hake": {
+                "concurrency_limit": 2,
+                "concurrency_tag": "shared-tag",
+            },
+        }
+    }
+
+    with pytest.raises(ValueError, match="Conflicting concurrency_limit"):
+        module._run_concurrency_setup(deploy_cfg)

--- a/tests/deployment/test_deploy_engine.py
+++ b/tests/deployment/test_deploy_engine.py
@@ -33,15 +33,13 @@ def test_filter_flows_for_deploy_uses_flow_alias_fallback(install_prefect_stubs)
     all_flows = {
         "copy_raw": {
             "flow_obj": object(),
-            "module_name": "flows_helper",
+            "flow_module": types.ModuleType("echodataflow.flows.flows_helper"),
             "flow_function_name": "flow_copy_raw",
-            "entrypoint": "echodataflow/flows/flows_helper.py:flow_copy_raw",
         },
         "file_upload": {
             "flow_obj": object(),
-            "module_name": "flows_helper",
+            "flow_module": types.ModuleType("echodataflow.flows.flows_helper"),
             "flow_function_name": "flow_file_upload",
-            "entrypoint": "echodataflow/flows/flows_helper.py:flow_file_upload",
         },
     }
     deploy_cfg = {
@@ -68,9 +66,8 @@ def test_filter_flows_for_deploy_raises_when_key_and_alias_missing(install_prefe
     all_flows = {
         "copy_raw": {
             "flow_obj": object(),
-            "module_name": "flows_helper",
+            "flow_module": types.ModuleType("echodataflow.flows.flows_helper"),
             "flow_function_name": "flow_copy_raw",
-            "entrypoint": "echodataflow/flows/flows_helper.py:flow_copy_raw",
         }
     }
     deploy_cfg = {
@@ -122,24 +119,20 @@ def test_local_deploy_specs_generate_current_flow_targets(install_prefect_stubs)
     for flow_key, flow_meta in deploy_ship["flows"].items():
         module_name = flow_meta["module"]
         flow_alias = flow_meta.get("flow_alias") or flow_key
-        entrypoint = f"echodataflow/flows/{module_name}.py:flow_{flow_alias}"
         ship_flows[flow_key] = {
             "flow_obj": object(),
-            "module_name": module_name,
+            "flow_module": types.ModuleType(f"echodataflow.flows.{module_name}"),
             "flow_function_name": f"flow_{flow_alias}",
-            "entrypoint": entrypoint,
         }
 
     cloud_flows = {}
     for flow_key, flow_meta in deploy_cloud["flows"].items():
         module_name = flow_meta["module"]
         flow_alias = flow_meta.get("flow_alias") or flow_key
-        entrypoint = f"echodataflow/flows/{module_name}.py:flow_{flow_alias}"
         cloud_flows[flow_key] = {
             "flow_obj": object(),
-            "module_name": module_name,
+            "flow_module": types.ModuleType(f"echodataflow.flows.{module_name}"),
             "flow_function_name": f"flow_{flow_alias}",
-            "entrypoint": entrypoint,
         }
 
     ship_specs = engine.build_deploy_specs(
@@ -192,9 +185,8 @@ def test_build_deploy_specs_rejects_empty_emit_events(install_prefect_stubs):
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "module_name": "flows_integration",
+            "flow_module": types.ModuleType("echodataflow.flows.flows_integration"),
             "flow_function_name": "flow_ingest_NASC",
-            "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
         }
     }
 
@@ -220,9 +212,8 @@ def test_build_deploy_specs_rejects_entrypoint_override(install_prefect_stubs):
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "module_name": "flows_integration",
+            "flow_module": types.ModuleType("echodataflow.flows.flows_integration"),
             "flow_function_name": "flow_ingest_NASC",
-            "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
         }
     }
 
@@ -251,9 +242,8 @@ def test_build_deploy_specs_rejects_triggers_and_interval(install_prefect_stubs)
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "module_name": "flows_integration",
+            "flow_module": types.ModuleType("echodataflow.flows.flows_integration"),
             "flow_function_name": "flow_ingest_NASC",
-            "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
         }
     }
 
@@ -278,9 +268,8 @@ def test_build_deploy_specs_rejects_missing_triggers_and_interval(install_prefec
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "module_name": "flows_integration",
+            "flow_module": types.ModuleType("echodataflow.flows.flows_integration"),
             "flow_function_name": "flow_ingest_NASC",
-            "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
         }
     }
 
@@ -306,9 +295,8 @@ def test_build_deploy_specs_rejects_empty_triggers(install_prefect_stubs):
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "module_name": "flows_integration",
+            "flow_module": types.ModuleType("echodataflow.flows.flows_integration"),
             "flow_function_name": "flow_ingest_NASC",
-            "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
         }
     }
 
@@ -336,9 +324,8 @@ def test_build_deploy_specs_rejects_trigger_missing_resource_name(install_prefec
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "module_name": "flows_integration",
+            "flow_module": types.ModuleType("echodataflow.flows.flows_integration"),
             "flow_function_name": "flow_ingest_NASC",
-            "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
         }
     }
 

--- a/tests/deployment/test_deploy_engine.py
+++ b/tests/deployment/test_deploy_engine.py
@@ -33,12 +33,12 @@ def test_filter_flows_for_deploy_uses_flow_alias_fallback(install_prefect_stubs)
     all_flows = {
         "copy_raw": {
             "flow_obj": object(),
-            "module_name": "flows_helper",
+            "flow_module": "flows_helper",
             "flow_function_name": "flow_copy_raw",
         },
         "file_upload": {
             "flow_obj": object(),
-            "module_name": "flows_helper",
+            "flow_module": "flows_helper",
             "flow_function_name": "flow_file_upload",
         },
     }
@@ -66,7 +66,7 @@ def test_filter_flows_for_deploy_raises_when_key_and_alias_missing(install_prefe
     all_flows = {
         "copy_raw": {
             "flow_obj": object(),
-            "module_name": "flows_helper",
+            "flow_module": "flows_helper",
             "flow_function_name": "flow_copy_raw",
         }
     }
@@ -121,7 +121,7 @@ def test_local_deploy_specs_generate_current_flow_targets(install_prefect_stubs)
         flow_alias = flow_meta.get("flow_alias") or flow_key
         ship_flows[flow_key] = {
             "flow_obj": object(),
-            "module_name": module_name,
+            "flow_module": module_name,
             "flow_function_name": f"flow_{flow_alias}",
         }
 
@@ -131,7 +131,7 @@ def test_local_deploy_specs_generate_current_flow_targets(install_prefect_stubs)
         flow_alias = flow_meta.get("flow_alias") or flow_key
         cloud_flows[flow_key] = {
             "flow_obj": object(),
-            "module_name": module_name,
+            "flow_module": module_name,
             "flow_function_name": f"flow_{flow_alias}",
         }
 
@@ -185,7 +185,7 @@ def test_build_deploy_specs_rejects_empty_emit_events(install_prefect_stubs):
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "module_name": "flows_integration",
+            "flow_module": "flows_integration",
             "flow_function_name": "flow_ingest_NASC",
         }
     }
@@ -212,7 +212,7 @@ def test_build_deploy_specs_rejects_entrypoint_override(install_prefect_stubs):
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "module_name": "flows_integration",
+            "flow_module": "flows_integration",
             "flow_function_name": "flow_ingest_NASC",
         }
     }
@@ -242,7 +242,7 @@ def test_build_deploy_specs_rejects_triggers_and_interval(install_prefect_stubs)
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "module_name": "flows_integration",
+            "flow_module": "flows_integration",
             "flow_function_name": "flow_ingest_NASC",
         }
     }
@@ -268,7 +268,7 @@ def test_build_deploy_specs_rejects_missing_triggers_and_interval(install_prefec
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "module_name": "flows_integration",
+            "flow_module": "flows_integration",
             "flow_function_name": "flow_ingest_NASC",
         }
     }
@@ -295,7 +295,7 @@ def test_build_deploy_specs_rejects_empty_triggers(install_prefect_stubs):
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "module_name": "flows_integration",
+            "flow_module": "flows_integration",
             "flow_function_name": "flow_ingest_NASC",
         }
     }
@@ -324,7 +324,7 @@ def test_build_deploy_specs_rejects_trigger_missing_resource_name(install_prefec
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "module_name": "flows_integration",
+            "flow_module": "flows_integration",
             "flow_function_name": "flow_ingest_NASC",
         }
     }

--- a/tests/deployment/test_deploy_engine.py
+++ b/tests/deployment/test_deploy_engine.py
@@ -259,3 +259,61 @@ def test_build_deploy_specs_rejects_missing_triggers_and_interval(install_prefec
             deploy_cfg=deploy_cfg,
             filtered_flows=filtered_flows,
         )
+
+
+def test_build_deploy_specs_rejects_empty_triggers(install_prefect_stubs):
+    install_prefect_stubs()
+    engine = importlib.import_module("echodataflow.deployment.deployment_engine")
+
+    deploy_cfg = {
+        "flows": {
+            "ingest_NASC": {
+                "deployment_name": "ingest_NASC",
+                "triggers": [],
+            }
+        }
+    }
+    filtered_flows = {
+        "ingest_NASC": {
+            "flow_obj": object(),
+            "module_name": "flows_integration",
+            "flow_attr_name": "flow_ingest_NASC",
+            "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
+        }
+    }
+
+    with pytest.raises(ValueError, match="must contain at least one trigger"):
+        engine.build_deploy_specs(
+            deploy_cfg=deploy_cfg,
+            filtered_flows=filtered_flows,
+        )
+
+
+def test_build_deploy_specs_rejects_trigger_missing_resource_name(install_prefect_stubs):
+    install_prefect_stubs()
+    engine = importlib.import_module("echodataflow.deployment.deployment_engine")
+
+    deploy_cfg = {
+        "flows": {
+            "ingest_NASC": {
+                "deployment_name": "ingest_NASC",
+                "triggers": [
+                    {"expect": "nasc.ingested"}
+                ],
+            }
+        }
+    }
+    filtered_flows = {
+        "ingest_NASC": {
+            "flow_obj": object(),
+            "module_name": "flows_integration",
+            "flow_attr_name": "flow_ingest_NASC",
+            "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
+        }
+    }
+
+    with pytest.raises(ValueError, match="non-empty 'resource_name'"):
+        engine.build_deploy_specs(
+            deploy_cfg=deploy_cfg,
+            filtered_flows=filtered_flows,
+        )

--- a/tests/deployment/test_deploy_engine.py
+++ b/tests/deployment/test_deploy_engine.py
@@ -201,3 +201,61 @@ def test_build_deploy_specs_rejects_entrypoint_override(install_prefect_stubs):
             deploy_cfg=deploy_cfg,
             filtered_flows=filtered_flows,
         )
+
+
+def test_build_deploy_specs_rejects_triggers_and_interval(install_prefect_stubs):
+    install_prefect_stubs()
+    engine = importlib.import_module("echodataflow.deployment.deployment_engine")
+
+    deploy_cfg = {
+        "flows": {
+            "ingest_NASC": {
+                "deployment_name": "ingest_NASC",
+                "interval": 5,
+                "triggers": [
+                    {"expect": "nasc.ingested", "resource_name": "ingest_NASC"}
+                ],
+            }
+        }
+    }
+    filtered_flows = {
+        "ingest_NASC": {
+            "flow_obj": object(),
+            "module_name": "flows_integration",
+            "flow_attr_name": "flow_ingest_NASC",
+            "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
+        }
+    }
+
+    with pytest.raises(ValueError, match="exactly one of 'triggers' or 'interval'"):
+        engine.build_deploy_specs(
+            deploy_cfg=deploy_cfg,
+            filtered_flows=filtered_flows,
+        )
+
+
+def test_build_deploy_specs_rejects_missing_triggers_and_interval(install_prefect_stubs):
+    install_prefect_stubs()
+    engine = importlib.import_module("echodataflow.deployment.deployment_engine")
+
+    deploy_cfg = {
+        "flows": {
+            "ingest_NASC": {
+                "deployment_name": "ingest_NASC",
+            }
+        }
+    }
+    filtered_flows = {
+        "ingest_NASC": {
+            "flow_obj": object(),
+            "module_name": "flows_integration",
+            "flow_attr_name": "flow_ingest_NASC",
+            "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
+        }
+    }
+
+    with pytest.raises(ValueError, match="exactly one of 'triggers' or 'interval'"):
+        engine.build_deploy_specs(
+            deploy_cfg=deploy_cfg,
+            filtered_flows=filtered_flows,
+        )

--- a/tests/deployment/test_deploy_engine.py
+++ b/tests/deployment/test_deploy_engine.py
@@ -86,13 +86,36 @@ def test_filter_flows_for_deploy_raises_when_key_and_alias_missing(install_prefe
         engine.filter_flows_for_deploy(all_flows, deploy_cfg)
 
 
-def test_local_deploy_specs_generate_current_flow_entrypoints(install_prefect_stubs):
+def test_local_deploy_specs_generate_current_flow_targets(install_prefect_stubs):
     install_prefect_stubs()
     engine = importlib.import_module("echodataflow.deployment.deployment_engine")
 
-    repo_root = Path(__file__).resolve().parents[2]
-    deploy_ship = engine.load_config(repo_root / "recipe" / "deploy" / "deploy_ship.yaml")
-    deploy_cloud = engine.load_config(repo_root / "recipe" / "deploy" / "deploy_cloud.yaml")
+    deploy_ship = {
+        "flows": {
+            "copy_raw": {"module": "flows_helper", "interval": 1},
+            "raw2Sv": {"module": "flows_acoustics", "interval": 1},
+            "create_MVBS": {"module": "flows_acoustics", "interval": 1},
+            "predict_hake": {"module": "flows_acoustics", "interval": 1},
+            "file_upload_acoustics": {
+                "module": "flows_helper",
+                "flow_alias": "file_upload",
+                "interval": 1,
+            },
+            "file_upload_trawl": {
+                "module": "flows_helper",
+                "flow_alias": "file_upload",
+                "interval": 1,
+            },
+        }
+    }
+    deploy_cloud = {
+        "flows": {
+            "ingest_haul": {"module": "flows_biology", "interval": 1},
+            "ingest_NASC": {"module": "flows_integration", "interval": 1},
+            "update_grid": {"module": "flows_integration", "interval": 1},
+            "update_cache_MVBS": {"module": "flows_viz_cloud", "interval": 1},
+        }
+    }
 
     # Build filtered flows mappings with mock flow objects
     ship_flows = {}
@@ -128,22 +151,28 @@ def test_local_deploy_specs_generate_current_flow_entrypoints(install_prefect_st
         filtered_flows=cloud_flows,
     )
 
-    ship_entrypoints = {spec.flow_key: spec.entrypoint for spec in ship_specs}
-    cloud_entrypoints = {spec.flow_key: spec.entrypoint for spec in cloud_specs}
-
-    assert ship_entrypoints == {
-        "copy_raw": "echodataflow/flows/flows_helper.py:flow_copy_raw",
-        "raw2Sv": "echodataflow/flows/flows_acoustics.py:flow_raw2Sv",
-        "create_MVBS": "echodataflow/flows/flows_acoustics.py:flow_create_MVBS",
-        "predict_hake": "echodataflow/flows/flows_acoustics.py:flow_predict_hake",
-        "file_upload_acoustics": "echodataflow/flows/flows_helper.py:flow_file_upload",
-        "file_upload_trawl": "echodataflow/flows/flows_helper.py:flow_file_upload",
+    ship_targets = {
+        spec.flow_key: (spec.flow_module, spec.flow_name)
+        for spec in ship_specs
     }
-    assert cloud_entrypoints == {
-        "ingest_haul": "echodataflow/flows/flows_biology.py:flow_ingest_haul",
-        "ingest_NASC": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
-        "update_grid": "echodataflow/flows/flows_integration.py:flow_update_grid",
-        "update_cache_MVBS": "echodataflow/flows/flows_viz_cloud.py:flow_update_cache_MVBS",
+    cloud_targets = {
+        spec.flow_key: (spec.flow_module, spec.flow_name)
+        for spec in cloud_specs
+    }
+
+    assert ship_targets == {
+        "copy_raw": ("flows_helper", "flow_copy_raw"),
+        "raw2Sv": ("flows_acoustics", "flow_raw2Sv"),
+        "create_MVBS": ("flows_acoustics", "flow_create_MVBS"),
+        "predict_hake": ("flows_acoustics", "flow_predict_hake"),
+        "file_upload_acoustics": ("flows_helper", "flow_file_upload"),
+        "file_upload_trawl": ("flows_helper", "flow_file_upload"),
+    }
+    assert cloud_targets == {
+        "ingest_haul": ("flows_biology", "flow_ingest_haul"),
+        "ingest_NASC": ("flows_integration", "flow_ingest_NASC"),
+        "update_grid": ("flows_integration", "flow_update_grid"),
+        "update_cache_MVBS": ("flows_viz_cloud", "flow_update_cache_MVBS"),
     }
 
 
@@ -155,6 +184,7 @@ def test_build_deploy_specs_rejects_empty_emit_events(install_prefect_stubs):
         "flows": {
             "ingest_NASC": {
                 "deployment_name": "ingest_NASC",
+                "interval": 5,
                 "emit_events": [],
             }
         }

--- a/tests/deployment/test_deploy_engine.py
+++ b/tests/deployment/test_deploy_engine.py
@@ -148,59 +148,48 @@ def test_local_deploy_specs_generate_current_flow_targets(install_prefect_stubs)
         filtered_flows=cloud_flows,
     )
 
-    ship_targets = {
-        spec.flow_key: (spec.parameters["flow_module"], spec.parameters["flow_name"])
-        for spec in ship_specs
-    }
-    cloud_targets = {
-        spec.flow_key: (spec.parameters["flow_module"], spec.parameters["flow_name"])
-        for spec in cloud_specs
-    }
+    ship_targets = {spec.flow_key: spec.entrypoint for spec in ship_specs}
+    cloud_targets = {spec.flow_key: spec.entrypoint for spec in cloud_specs}
 
     assert ship_targets == {
-        "copy_raw": ("flows_helper", "flow_copy_raw"),
-        "raw2Sv": ("flows_acoustics", "flow_raw2Sv"),
-        "create_MVBS": ("flows_acoustics", "flow_create_MVBS"),
-        "predict_hake": ("flows_acoustics", "flow_predict_hake"),
-        "file_upload_acoustics": ("flows_helper", "flow_file_upload"),
-        "file_upload_trawl": ("flows_helper", "flow_file_upload"),
+        "copy_raw": "echodataflow/flows/flows_helper.py:flow_copy_raw",
+        "raw2Sv": "echodataflow/flows/flows_acoustics.py:flow_raw2Sv",
+        "create_MVBS": "echodataflow/flows/flows_acoustics.py:flow_create_MVBS",
+        "predict_hake": "echodataflow/flows/flows_acoustics.py:flow_predict_hake",
+        "file_upload_acoustics": "echodataflow/flows/flows_helper.py:flow_file_upload",
+        "file_upload_trawl": "echodataflow/flows/flows_helper.py:flow_file_upload",
     }
     assert cloud_targets == {
-        "ingest_haul": ("flows_biology", "flow_ingest_haul"),
-        "ingest_NASC": ("flows_integration", "flow_ingest_NASC"),
-        "update_grid": ("flows_integration", "flow_update_grid"),
-        "update_cache_MVBS": ("flows_viz_cloud", "flow_update_cache_MVBS"),
+        "ingest_haul": "echodataflow/flows/flows_biology.py:flow_ingest_haul",
+        "ingest_NASC": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
+        "update_grid": "echodataflow/flows/flows_integration.py:flow_update_grid",
+        "update_cache_MVBS": "echodataflow/flows/flows_viz_cloud.py:flow_update_cache_MVBS",
     }
 
 
-def test_build_deploy_specs_rejects_empty_emit_events(install_prefect_stubs):
+def test_build_deploy_specs_passes_target_flow_parameters_directly(install_prefect_stubs):
     install_prefect_stubs()
     engine = importlib.import_module("echodataflow.deployment.deployment_engine")
 
-    deploy_cfg = {
-        "flows": {
-            "ingest_NASC": {
-                "deployment_name": "ingest_NASC",
-                "interval": 5,
-                "emit_events": [],
+    specs = engine.build_deploy_specs(
+        param_cfg={"flows": {"emit_event_ABC": {"msg": "hello"}}},
+        deploy_cfg={
+            "flows": {
+                "emit_event_ABC": {
+                    "interval": 1,
+                }
             }
-        }
-    }
-    filtered_flows = {
-        "ingest_NASC": {
-            "flow_obj": object(),
-            "flow_module": "flows_integration",
-            "flow_function_name": "flow_ingest_NASC",
-        }
-    }
-    param_cfg = {"flows": {"ingest_NASC": {}}}
+        },
+        filtered_flows={
+            "emit_event_ABC": {
+                "flow_obj": object(),
+                "flow_module": "flows_test",
+                "flow_function_name": "flow_emit_event_ABC",
+            }
+        },
+    )
 
-    with pytest.raises(ValueError, match="at least one event name"):
-        engine.build_deploy_specs(
-            param_cfg=param_cfg,
-            deploy_cfg=deploy_cfg,
-            filtered_flows=filtered_flows,
-        )
+    assert specs[0].parameters == {"msg": "hello"}
 
 
 def test_build_deploy_specs_rejects_entrypoint_override(install_prefect_stubs):

--- a/tests/deployment/test_deploy_engine.py
+++ b/tests/deployment/test_deploy_engine.py
@@ -34,13 +34,13 @@ def test_filter_flows_for_deploy_uses_flow_alias_fallback(install_prefect_stubs)
         "copy_raw": {
             "flow_obj": object(),
             "module_name": "flows_helper",
-            "flow_attr_name": "flow_copy_raw",
+            "flow_function_name": "flow_copy_raw",
             "entrypoint": "echodataflow/flows/flows_helper.py:flow_copy_raw",
         },
         "file_upload": {
             "flow_obj": object(),
             "module_name": "flows_helper",
-            "flow_attr_name": "flow_file_upload",
+            "flow_function_name": "flow_file_upload",
             "entrypoint": "echodataflow/flows/flows_helper.py:flow_file_upload",
         },
     }
@@ -69,7 +69,7 @@ def test_filter_flows_for_deploy_raises_when_key_and_alias_missing(install_prefe
         "copy_raw": {
             "flow_obj": object(),
             "module_name": "flows_helper",
-            "flow_attr_name": "flow_copy_raw",
+            "flow_function_name": "flow_copy_raw",
             "entrypoint": "echodataflow/flows/flows_helper.py:flow_copy_raw",
         }
     }
@@ -103,7 +103,7 @@ def test_local_deploy_specs_generate_current_flow_entrypoints(install_prefect_st
         ship_flows[flow_key] = {
             "flow_obj": object(),
             "module_name": module_name,
-            "flow_attr_name": f"flow_{flow_alias}",
+            "flow_function_name": f"flow_{flow_alias}",
             "entrypoint": entrypoint,
         }
 
@@ -115,7 +115,7 @@ def test_local_deploy_specs_generate_current_flow_entrypoints(install_prefect_st
         cloud_flows[flow_key] = {
             "flow_obj": object(),
             "module_name": module_name,
-            "flow_attr_name": f"flow_{flow_alias}",
+            "flow_function_name": f"flow_{flow_alias}",
             "entrypoint": entrypoint,
         }
 
@@ -163,7 +163,7 @@ def test_build_deploy_specs_rejects_empty_emit_events(install_prefect_stubs):
         "ingest_NASC": {
             "flow_obj": object(),
             "module_name": "flows_integration",
-            "flow_attr_name": "flow_ingest_NASC",
+            "flow_function_name": "flow_ingest_NASC",
             "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
         }
     }
@@ -191,7 +191,7 @@ def test_build_deploy_specs_rejects_entrypoint_override(install_prefect_stubs):
         "ingest_NASC": {
             "flow_obj": object(),
             "module_name": "flows_integration",
-            "flow_attr_name": "flow_ingest_NASC",
+            "flow_function_name": "flow_ingest_NASC",
             "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
         }
     }
@@ -222,7 +222,7 @@ def test_build_deploy_specs_rejects_triggers_and_interval(install_prefect_stubs)
         "ingest_NASC": {
             "flow_obj": object(),
             "module_name": "flows_integration",
-            "flow_attr_name": "flow_ingest_NASC",
+            "flow_function_name": "flow_ingest_NASC",
             "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
         }
     }
@@ -249,7 +249,7 @@ def test_build_deploy_specs_rejects_missing_triggers_and_interval(install_prefec
         "ingest_NASC": {
             "flow_obj": object(),
             "module_name": "flows_integration",
-            "flow_attr_name": "flow_ingest_NASC",
+            "flow_function_name": "flow_ingest_NASC",
             "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
         }
     }
@@ -277,7 +277,7 @@ def test_build_deploy_specs_rejects_empty_triggers(install_prefect_stubs):
         "ingest_NASC": {
             "flow_obj": object(),
             "module_name": "flows_integration",
-            "flow_attr_name": "flow_ingest_NASC",
+            "flow_function_name": "flow_ingest_NASC",
             "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
         }
     }
@@ -307,7 +307,7 @@ def test_build_deploy_specs_rejects_trigger_missing_resource_name(install_prefec
         "ingest_NASC": {
             "flow_obj": object(),
             "module_name": "flows_integration",
-            "flow_attr_name": "flow_ingest_NASC",
+            "flow_function_name": "flow_ingest_NASC",
             "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
         }
     }

--- a/tests/deployment/test_deploy_engine.py
+++ b/tests/deployment/test_deploy_engine.py
@@ -33,12 +33,12 @@ def test_filter_flows_for_deploy_uses_flow_alias_fallback(install_prefect_stubs)
     all_flows = {
         "copy_raw": {
             "flow_obj": object(),
-            "flow_module": types.ModuleType("echodataflow.flows.flows_helper"),
+            "module_name": "flows_helper",
             "flow_function_name": "flow_copy_raw",
         },
         "file_upload": {
             "flow_obj": object(),
-            "flow_module": types.ModuleType("echodataflow.flows.flows_helper"),
+            "module_name": "flows_helper",
             "flow_function_name": "flow_file_upload",
         },
     }
@@ -66,7 +66,7 @@ def test_filter_flows_for_deploy_raises_when_key_and_alias_missing(install_prefe
     all_flows = {
         "copy_raw": {
             "flow_obj": object(),
-            "flow_module": types.ModuleType("echodataflow.flows.flows_helper"),
+            "module_name": "flows_helper",
             "flow_function_name": "flow_copy_raw",
         }
     }
@@ -121,7 +121,7 @@ def test_local_deploy_specs_generate_current_flow_targets(install_prefect_stubs)
         flow_alias = flow_meta.get("flow_alias") or flow_key
         ship_flows[flow_key] = {
             "flow_obj": object(),
-            "flow_module": types.ModuleType(f"echodataflow.flows.{module_name}"),
+            "module_name": module_name,
             "flow_function_name": f"flow_{flow_alias}",
         }
 
@@ -131,7 +131,7 @@ def test_local_deploy_specs_generate_current_flow_targets(install_prefect_stubs)
         flow_alias = flow_meta.get("flow_alias") or flow_key
         cloud_flows[flow_key] = {
             "flow_obj": object(),
-            "flow_module": types.ModuleType(f"echodataflow.flows.{module_name}"),
+            "module_name": module_name,
             "flow_function_name": f"flow_{flow_alias}",
         }
 
@@ -185,7 +185,7 @@ def test_build_deploy_specs_rejects_empty_emit_events(install_prefect_stubs):
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "flow_module": types.ModuleType("echodataflow.flows.flows_integration"),
+            "module_name": "flows_integration",
             "flow_function_name": "flow_ingest_NASC",
         }
     }
@@ -212,7 +212,7 @@ def test_build_deploy_specs_rejects_entrypoint_override(install_prefect_stubs):
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "flow_module": types.ModuleType("echodataflow.flows.flows_integration"),
+            "module_name": "flows_integration",
             "flow_function_name": "flow_ingest_NASC",
         }
     }
@@ -242,7 +242,7 @@ def test_build_deploy_specs_rejects_triggers_and_interval(install_prefect_stubs)
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "flow_module": types.ModuleType("echodataflow.flows.flows_integration"),
+            "module_name": "flows_integration",
             "flow_function_name": "flow_ingest_NASC",
         }
     }
@@ -268,7 +268,7 @@ def test_build_deploy_specs_rejects_missing_triggers_and_interval(install_prefec
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "flow_module": types.ModuleType("echodataflow.flows.flows_integration"),
+            "module_name": "flows_integration",
             "flow_function_name": "flow_ingest_NASC",
         }
     }
@@ -295,7 +295,7 @@ def test_build_deploy_specs_rejects_empty_triggers(install_prefect_stubs):
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "flow_module": types.ModuleType("echodataflow.flows.flows_integration"),
+            "module_name": "flows_integration",
             "flow_function_name": "flow_ingest_NASC",
         }
     }
@@ -324,7 +324,7 @@ def test_build_deploy_specs_rejects_trigger_missing_resource_name(install_prefec
     filtered_flows = {
         "ingest_NASC": {
             "flow_obj": object(),
-            "flow_module": types.ModuleType("echodataflow.flows.flows_integration"),
+            "module_name": "flows_integration",
             "flow_function_name": "flow_ingest_NASC",
         }
     }

--- a/tests/deployment/test_deploy_engine.py
+++ b/tests/deployment/test_deploy_engine.py
@@ -34,11 +34,13 @@ def test_filter_flows_for_deploy_uses_flow_alias_fallback(install_prefect_stubs)
         "copy_raw": {
             "flow_obj": object(),
             "module_name": "flows_helper",
+            "flow_attr_name": "flow_copy_raw",
             "entrypoint": "echodataflow/flows/flows_helper.py:flow_copy_raw",
         },
         "file_upload": {
             "flow_obj": object(),
             "module_name": "flows_helper",
+            "flow_attr_name": "flow_file_upload",
             "entrypoint": "echodataflow/flows/flows_helper.py:flow_file_upload",
         },
     }
@@ -67,6 +69,7 @@ def test_filter_flows_for_deploy_raises_when_key_and_alias_missing(install_prefe
         "copy_raw": {
             "flow_obj": object(),
             "module_name": "flows_helper",
+            "flow_attr_name": "flow_copy_raw",
             "entrypoint": "echodataflow/flows/flows_helper.py:flow_copy_raw",
         }
     }
@@ -100,6 +103,7 @@ def test_local_deploy_specs_generate_current_flow_entrypoints(install_prefect_st
         ship_flows[flow_key] = {
             "flow_obj": object(),
             "module_name": module_name,
+            "flow_attr_name": f"flow_{flow_alias}",
             "entrypoint": entrypoint,
         }
 
@@ -111,6 +115,7 @@ def test_local_deploy_specs_generate_current_flow_entrypoints(install_prefect_st
         cloud_flows[flow_key] = {
             "flow_obj": object(),
             "module_name": module_name,
+            "flow_attr_name": f"flow_{flow_alias}",
             "entrypoint": entrypoint,
         }
 
@@ -158,11 +163,40 @@ def test_build_deploy_specs_rejects_empty_emit_events(install_prefect_stubs):
         "ingest_NASC": {
             "flow_obj": object(),
             "module_name": "flows_integration",
+            "flow_attr_name": "flow_ingest_NASC",
             "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
         }
     }
 
     with pytest.raises(ValueError, match="at least one event name"):
+        engine.build_deploy_specs(
+            deploy_cfg=deploy_cfg,
+            filtered_flows=filtered_flows,
+        )
+
+
+def test_build_deploy_specs_rejects_entrypoint_override(install_prefect_stubs):
+    install_prefect_stubs()
+    engine = importlib.import_module("echodataflow.deployment.deployment_engine")
+
+    deploy_cfg = {
+        "flows": {
+            "ingest_NASC": {
+                "deployment_name": "ingest_NASC",
+                "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
+            }
+        }
+    }
+    filtered_flows = {
+        "ingest_NASC": {
+            "flow_obj": object(),
+            "module_name": "flows_integration",
+            "flow_attr_name": "flow_ingest_NASC",
+            "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
+        }
+    }
+
+    with pytest.raises(ValueError, match="entrypoint is not supported"):
         engine.build_deploy_specs(
             deploy_cfg=deploy_cfg,
             filtered_flows=filtered_flows,

--- a/tests/deployment/test_deploy_engine.py
+++ b/tests/deployment/test_deploy_engine.py
@@ -113,6 +113,8 @@ def test_local_deploy_specs_generate_current_flow_targets(install_prefect_stubs)
             "update_cache_MVBS": {"module": "flows_viz_cloud", "interval": 1},
         }
     }
+    param_ship = {"flows": {flow_key: {} for flow_key in deploy_ship["flows"]}}
+    param_cloud = {"flows": {flow_key: {} for flow_key in deploy_cloud["flows"]}}
 
     # Build filtered flows mappings with mock flow objects
     ship_flows = {}
@@ -136,20 +138,22 @@ def test_local_deploy_specs_generate_current_flow_targets(install_prefect_stubs)
         }
 
     ship_specs = engine.build_deploy_specs(
+        param_cfg=param_ship,
         deploy_cfg=deploy_ship,
         filtered_flows=ship_flows,
     )
     cloud_specs = engine.build_deploy_specs(
+        param_cfg=param_cloud,
         deploy_cfg=deploy_cloud,
         filtered_flows=cloud_flows,
     )
 
     ship_targets = {
-        spec.flow_key: (spec.flow_module, spec.flow_name)
+        spec.flow_key: (spec.parameters["flow_module"], spec.parameters["flow_name"])
         for spec in ship_specs
     }
     cloud_targets = {
-        spec.flow_key: (spec.flow_module, spec.flow_name)
+        spec.flow_key: (spec.parameters["flow_module"], spec.parameters["flow_name"])
         for spec in cloud_specs
     }
 
@@ -189,9 +193,11 @@ def test_build_deploy_specs_rejects_empty_emit_events(install_prefect_stubs):
             "flow_function_name": "flow_ingest_NASC",
         }
     }
+    param_cfg = {"flows": {"ingest_NASC": {}}}
 
     with pytest.raises(ValueError, match="at least one event name"):
         engine.build_deploy_specs(
+            param_cfg=param_cfg,
             deploy_cfg=deploy_cfg,
             filtered_flows=filtered_flows,
         )
@@ -216,9 +222,11 @@ def test_build_deploy_specs_rejects_entrypoint_override(install_prefect_stubs):
             "flow_function_name": "flow_ingest_NASC",
         }
     }
+    param_cfg = {"flows": {"ingest_NASC": {}}}
 
     with pytest.raises(ValueError, match="entrypoint is not supported"):
         engine.build_deploy_specs(
+            param_cfg=param_cfg,
             deploy_cfg=deploy_cfg,
             filtered_flows=filtered_flows,
         )
@@ -246,9 +254,11 @@ def test_build_deploy_specs_rejects_triggers_and_interval(install_prefect_stubs)
             "flow_function_name": "flow_ingest_NASC",
         }
     }
+    param_cfg = {"flows": {"ingest_NASC": {}}}
 
     with pytest.raises(ValueError, match="exactly one of 'triggers' or 'interval'"):
         engine.build_deploy_specs(
+            param_cfg=param_cfg,
             deploy_cfg=deploy_cfg,
             filtered_flows=filtered_flows,
         )
@@ -272,9 +282,11 @@ def test_build_deploy_specs_rejects_missing_triggers_and_interval(install_prefec
             "flow_function_name": "flow_ingest_NASC",
         }
     }
+    param_cfg = {"flows": {"ingest_NASC": {}}}
 
     with pytest.raises(ValueError, match="exactly one of 'triggers' or 'interval'"):
         engine.build_deploy_specs(
+            param_cfg=param_cfg,
             deploy_cfg=deploy_cfg,
             filtered_flows=filtered_flows,
         )
@@ -299,9 +311,11 @@ def test_build_deploy_specs_rejects_empty_triggers(install_prefect_stubs):
             "flow_function_name": "flow_ingest_NASC",
         }
     }
+    param_cfg = {"flows": {"ingest_NASC": {}}}
 
     with pytest.raises(ValueError, match="must contain at least one trigger"):
         engine.build_deploy_specs(
+            param_cfg=param_cfg,
             deploy_cfg=deploy_cfg,
             filtered_flows=filtered_flows,
         )
@@ -328,9 +342,11 @@ def test_build_deploy_specs_rejects_trigger_missing_resource_name(install_prefec
             "flow_function_name": "flow_ingest_NASC",
         }
     }
+    param_cfg = {"flows": {"ingest_NASC": {}}}
 
     with pytest.raises(ValueError, match="non-empty 'resource_name'"):
         engine.build_deploy_specs(
+            param_cfg=param_cfg,
             deploy_cfg=deploy_cfg,
             filtered_flows=filtered_flows,
         )

--- a/tests/deployment/test_deploy_engine.py
+++ b/tests/deployment/test_deploy_engine.py
@@ -350,3 +350,42 @@ def test_build_deploy_specs_rejects_trigger_missing_resource_name(install_prefec
             deploy_cfg=deploy_cfg,
             filtered_flows=filtered_flows,
         )
+
+
+def test_build_deploy_specs_rejects_inject_time_offset_for_incompatible_flow(
+    install_prefect_stubs,
+):
+    install_prefect_stubs()
+    engine = importlib.import_module("echodataflow.deployment.deployment_engine")
+
+    def _incompatible_flow_fn(path_main: str = ""):
+        return None
+
+    class _FakeFlow:
+        fn = _incompatible_flow_fn
+
+    deploy_cfg = {
+        "flow_start_time": "2026-01-01T00:00:00+00:00",
+        "flows": {
+            "create_MVBS": {
+                "deployment_name": "create_MVBS",
+                "interval": 5,
+                "inject_time_offset": True,
+            }
+        },
+    }
+    param_cfg = {"flows": {"create_MVBS": {"path_main": "/tmp"}}}
+    filtered_flows = {
+        "create_MVBS": {
+            "flow_obj": _FakeFlow(),
+            "flow_module": "flows_acoustics",
+            "flow_function_name": "flow_create_MVBS",
+        }
+    }
+
+    with pytest.raises(ValueError, match="does not define 'time_offset_seconds'"):
+        engine.build_deploy_specs(
+            param_cfg=param_cfg,
+            deploy_cfg=deploy_cfg,
+            filtered_flows=filtered_flows,
+        )

--- a/tests/deployment/test_deploy_engine.py
+++ b/tests/deployment/test_deploy_engine.py
@@ -44,9 +44,8 @@ def test_filter_flows_for_deploy_uses_flow_alias_fallback(install_prefect_stubs)
     }
     deploy_cfg = {
         "flows": {
-            "copy_raw": {"module": "flows_helper"},
+            "copy_raw": {},
             "file_upload_acoustics": {
-                "module": "flows_helper",
                 "flow_alias": "file_upload",
             },
         }
@@ -73,7 +72,6 @@ def test_filter_flows_for_deploy_raises_when_key_and_alias_missing(install_prefe
     deploy_cfg = {
         "flows": {
             "file_upload_acoustics": {
-                "module": "flows_helper",
                 "flow_alias": "file_upload",
             }
         }
@@ -89,17 +87,15 @@ def test_local_deploy_specs_generate_current_flow_targets(install_prefect_stubs)
 
     deploy_ship = {
         "flows": {
-            "copy_raw": {"module": "flows_helper", "interval": 1},
-            "raw2Sv": {"module": "flows_acoustics", "interval": 1},
-            "create_MVBS": {"module": "flows_acoustics", "interval": 1},
-            "predict_hake": {"module": "flows_acoustics", "interval": 1},
+            "copy_raw": {"interval": 1},
+            "raw2Sv": {"interval": 1},
+            "create_MVBS": {"interval": 1},
+            "predict_hake": {"interval": 1},
             "file_upload_acoustics": {
-                "module": "flows_helper",
                 "flow_alias": "file_upload",
                 "interval": 1,
             },
             "file_upload_trawl": {
-                "module": "flows_helper",
                 "flow_alias": "file_upload",
                 "interval": 1,
             },
@@ -107,10 +103,10 @@ def test_local_deploy_specs_generate_current_flow_targets(install_prefect_stubs)
     }
     deploy_cloud = {
         "flows": {
-            "ingest_haul": {"module": "flows_biology", "interval": 1},
-            "ingest_NASC": {"module": "flows_integration", "interval": 1},
-            "update_grid": {"module": "flows_integration", "interval": 1},
-            "update_cache_MVBS": {"module": "flows_viz_cloud", "interval": 1},
+            "ingest_haul": {"interval": 1},
+            "ingest_NASC": {"interval": 1},
+            "update_grid": {"interval": 1},
+            "update_cache_MVBS": {"interval": 1},
         }
     }
     param_ship = {"flows": {flow_key: {} for flow_key in deploy_ship["flows"]}}
@@ -118,8 +114,16 @@ def test_local_deploy_specs_generate_current_flow_targets(install_prefect_stubs)
 
     # Build filtered flows mappings with mock flow objects
     ship_flows = {}
+    ship_modules = {
+        "copy_raw": "flows_helper",
+        "raw2Sv": "flows_acoustics",
+        "create_MVBS": "flows_acoustics",
+        "predict_hake": "flows_acoustics",
+        "file_upload_acoustics": "flows_helper",
+        "file_upload_trawl": "flows_helper",
+    }
     for flow_key, flow_meta in deploy_ship["flows"].items():
-        module_name = flow_meta["module"]
+        module_name = ship_modules[flow_key]
         flow_alias = flow_meta.get("flow_alias") or flow_key
         ship_flows[flow_key] = {
             "flow_obj": object(),
@@ -128,8 +132,14 @@ def test_local_deploy_specs_generate_current_flow_targets(install_prefect_stubs)
         }
 
     cloud_flows = {}
+    cloud_modules = {
+        "ingest_haul": "flows_biology",
+        "ingest_NASC": "flows_integration",
+        "update_grid": "flows_integration",
+        "update_cache_MVBS": "flows_viz_cloud",
+    }
     for flow_key, flow_meta in deploy_cloud["flows"].items():
-        module_name = flow_meta["module"]
+        module_name = cloud_modules[flow_key]
         flow_alias = flow_meta.get("flow_alias") or flow_key
         cloud_flows[flow_key] = {
             "flow_obj": object(),
@@ -192,33 +202,158 @@ def test_build_deploy_specs_passes_target_flow_parameters_directly(install_prefe
     assert specs[0].parameters == {"msg": "hello"}
 
 
-def test_build_deploy_specs_rejects_entrypoint_override(install_prefect_stubs):
+def test_validate_deploy_config_accepts_every_allowed_key(install_prefect_stubs):
     install_prefect_stubs()
+    core = importlib.import_module("echodataflow.deployment.core")
     engine = importlib.import_module("echodataflow.deployment.deployment_engine")
 
     deploy_cfg = {
+        "flow_start_time": "2026-01-01T00:00:00+00:00",
+        "default_work_pool_name": "default-pool",
+        "source": {
+            "mode": "git",
+            "git": {
+                "url": "https://example.com/repo.git",
+                "branch": "main",
+            },
+        },
         "flows": {
-            "ingest_NASC": {
-                "deployment_name": "ingest_NASC",
-                "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
-            }
-        }
+            "scheduled": {
+                "deployment_name": "scheduled-deployment",
+                "flow_alias": "actual_flow_name",
+                "interval": 10,
+                "cron_offset": 3,
+                "inject_time_offset": True,
+                "work_pool_name": "special-pool",
+            },
+            "event_driven": {
+                "triggers": [
+                    {
+                        "expect": "prefect.flow-run.Completed",
+                        "resource_name": "scheduled-deployment",
+                    }
+                ],
+            },
+        },
     }
-    filtered_flows = {
-        "ingest_NASC": {
-            "flow_obj": object(),
-            "flow_module": "flows_integration",
-            "flow_function_name": "flow_ingest_NASC",
-        }
-    }
-    param_cfg = {"flows": {"ingest_NASC": {}}}
 
-    with pytest.raises(ValueError, match="entrypoint is not supported"):
-        engine.build_deploy_specs(
-            param_cfg=param_cfg,
-            deploy_cfg=deploy_cfg,
-            filtered_flows=filtered_flows,
-        )
+    engine.validate_deploy_config(deploy_cfg)
+
+    assert core.ALLOWED_DEPLOY_KEYS == {
+        "flow_start_time",
+        "default_work_pool_name",
+        "source",
+        "flows",
+    }
+    assert core.ALLOWED_FLOW_DEPLOY_KEYS == {
+        "deployment_name",
+        "flow_alias",
+        "interval",
+        "cron_offset",
+        "triggers",
+        "inject_time_offset",
+        "work_pool_name",
+    }
+    assert core.ALLOWED_TRIGGER_KEYS == {"expect", "resource_name"}
+    assert core.ALLOWED_SOURCE_KEYS == {"mode", "git"}
+    assert core.ALLOWED_GIT_SOURCE_KEYS == {"url", "branch"}
+
+
+@pytest.mark.parametrize(
+    ("deploy_cfg", "expected_path", "unknown_field"),
+    [
+        (
+            {"flows": {}, "default_workpool_name": "local"},
+            "deploy_cfg",
+            "default_workpool_name",
+        ),
+        (
+            {"flows": {"upstream": {"entrypoint": "flows.py:upstream"}}},
+            "deploy_cfg.flows.upstream",
+            "entrypoint",
+        ),
+        (
+            {
+                "flows": {
+                    "downstream": {
+                        "triggers": [
+                            {
+                                "expect": "prefect.flow-run.Completed",
+                                "resource_name": "upstream",
+                                "resource_role": "deployment",
+                            }
+                        ]
+                    }
+                }
+            },
+            "deploy_cfg.flows.downstream.triggers[0]",
+            "resource_role",
+        ),
+        (
+            {"flows": {}, "source": {"mode": "local", "directory": "/tmp"}},
+            "deploy_cfg.source",
+            "directory",
+        ),
+        (
+            {
+                "flows": {},
+                "source": {
+                    "mode": "git",
+                    "git": {"url": "https://example.com/repo.git", "ref": "main"},
+                },
+            },
+            "deploy_cfg.source.git",
+            "ref",
+        ),
+    ],
+)
+def test_validate_deploy_config_rejects_unknown_nested_fields(
+    install_prefect_stubs,
+    deploy_cfg,
+    expected_path,
+    unknown_field,
+):
+    install_prefect_stubs()
+    engine = importlib.import_module("echodataflow.deployment.deployment_engine")
+
+    with pytest.raises(ValueError) as exc_info:
+        engine.validate_deploy_config(deploy_cfg)
+
+    message = str(exc_info.value)
+    assert expected_path in message
+    assert unknown_field in message
+
+
+@pytest.mark.parametrize(
+    ("deploy_cfg", "expected_message"),
+    [
+        (None, "deploy_cfg must be a mapping"),
+        ({}, "deploy_cfg.flows must be a mapping"),
+        ({"flows": []}, "deploy_cfg.flows must be a mapping"),
+        (
+            {"flows": {"raw2Sv": []}},
+            "deploy_cfg.flows.raw2Sv must be a mapping",
+        ),
+        (
+            {"flows": {}, "source": "local"},
+            "deploy_cfg.source must be a mapping",
+        ),
+        (
+            {"flows": {}, "source": {"mode": "git", "git": "repo"}},
+            "deploy_cfg.source.git must be a mapping",
+        ),
+    ],
+)
+def test_validate_deploy_config_rejects_invalid_mapping_shapes(
+    install_prefect_stubs,
+    deploy_cfg,
+    expected_message,
+):
+    install_prefect_stubs()
+    engine = importlib.import_module("echodataflow.deployment.deployment_engine")
+
+    with pytest.raises(ValueError, match=expected_message):
+        engine.validate_deploy_config(deploy_cfg)
 
 
 def test_build_deploy_specs_rejects_triggers_and_interval(install_prefect_stubs):
@@ -245,7 +380,7 @@ def test_build_deploy_specs_rejects_triggers_and_interval(install_prefect_stubs)
     }
     param_cfg = {"flows": {"ingest_NASC": {}}}
 
-    with pytest.raises(ValueError, match="exactly one of 'triggers' or 'interval'"):
+    with pytest.raises(ValueError, match="only one of 'triggers' or 'interval'"):
         engine.build_deploy_specs(
             param_cfg=param_cfg,
             deploy_cfg=deploy_cfg,
@@ -253,7 +388,9 @@ def test_build_deploy_specs_rejects_triggers_and_interval(install_prefect_stubs)
         )
 
 
-def test_build_deploy_specs_rejects_missing_triggers_and_interval(install_prefect_stubs):
+def test_build_deploy_specs_allows_manual_deployment_without_schedule(
+    install_prefect_stubs,
+):
     install_prefect_stubs()
     engine = importlib.import_module("echodataflow.deployment.deployment_engine")
 
@@ -273,12 +410,15 @@ def test_build_deploy_specs_rejects_missing_triggers_and_interval(install_prefec
     }
     param_cfg = {"flows": {"ingest_NASC": {}}}
 
-    with pytest.raises(ValueError, match="exactly one of 'triggers' or 'interval'"):
-        engine.build_deploy_specs(
-            param_cfg=param_cfg,
-            deploy_cfg=deploy_cfg,
-            filtered_flows=filtered_flows,
-        )
+    specs = engine.build_deploy_specs(
+        param_cfg=param_cfg,
+        deploy_cfg=deploy_cfg,
+        filtered_flows=filtered_flows,
+    )
+
+    assert len(specs) == 1
+    assert specs[0].cron is None
+    assert specs[0].triggers is None
 
 
 def test_build_deploy_specs_rejects_empty_triggers(install_prefect_stubs):

--- a/tests/deployment/test_deploy_engine.py
+++ b/tests/deployment/test_deploy_engine.py
@@ -140,3 +140,30 @@ def test_local_deploy_specs_generate_current_flow_entrypoints(install_prefect_st
         "update_grid": "echodataflow/flows/flows_integration.py:flow_update_grid",
         "update_cache_MVBS": "echodataflow/flows/flows_viz_cloud.py:flow_update_cache_MVBS",
     }
+
+
+def test_build_deploy_specs_rejects_empty_emit_events(install_prefect_stubs):
+    install_prefect_stubs()
+    engine = importlib.import_module("echodataflow.deployment.deployment_engine")
+
+    deploy_cfg = {
+        "flows": {
+            "ingest_NASC": {
+                "deployment_name": "ingest_NASC",
+                "emit_events": [],
+            }
+        }
+    }
+    filtered_flows = {
+        "ingest_NASC": {
+            "flow_obj": object(),
+            "module_name": "flows_integration",
+            "entrypoint": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
+        }
+    }
+
+    with pytest.raises(ValueError, match="at least one event name"):
+        engine.build_deploy_specs(
+            deploy_cfg=deploy_cfg,
+            filtered_flows=filtered_flows,
+        )

--- a/tests/deployment/test_deploy_ship_cloud.py
+++ b/tests/deployment/test_deploy_ship_cloud.py
@@ -157,7 +157,6 @@ def test_deploy_cli_cloud_characterization(monkeypatch, tmp_path, install_prefec
     module._run_from_specs(
         param_cfg_path=Path("config_cloud.yaml"),
         deploy_cfg_path=Path("deploy_cloud.yaml"),
-        source_mode="local",
         run_concurrency_setup=False,
         default_work_pool_name="local",
     )
@@ -249,7 +248,6 @@ def test_deploy_cli_ship_characterization(monkeypatch, tmp_path, install_prefect
                 "deployment_name": "file-upload-acoustics_leg2",
                 "flow_alias": "file_upload",
                 "interval": 10,
-                "apply_separately": True,
                 "work_pool_name": "local",
             },
             "file_upload_trawl": {
@@ -257,7 +255,6 @@ def test_deploy_cli_ship_characterization(monkeypatch, tmp_path, install_prefect
                 "deployment_name": "file-upload-trawl_20250902",
                 "flow_alias": "file_upload",
                 "interval": 10,
-                "apply_separately": True,
                 "work_pool_name": "local",
             },
         },
@@ -303,7 +300,6 @@ def test_deploy_cli_ship_characterization(monkeypatch, tmp_path, install_prefect
     module._run_from_specs(
         param_cfg_path=Path("config_ship.yaml"),
         deploy_cfg_path=Path("deploy_ship.yaml"),
-        source_mode="local",
         run_concurrency_setup=False,
         default_work_pool_name="local",
     )
@@ -322,4 +318,4 @@ def test_deploy_cli_ship_characterization(monkeypatch, tmp_path, install_prefect
 
     assert sink["deploy_call"]["kwargs"]["work_pool_name"] == "local"
     assert len(sink["deployments"]) == 5
-    assert len(sink["applied"]) == 2
+    assert len(sink["applied"]) == 0

--- a/tests/deployment/test_deploy_ship_cloud.py
+++ b/tests/deployment/test_deploy_ship_cloud.py
@@ -142,7 +142,7 @@ def test_deploy_cli_cloud_characterization(monkeypatch, tmp_path, install_prefec
         flow_obj = getattr(flow_module, flow_name)
         filtered[flow_key] = {
             "flow_obj": flow_obj,
-            "module_name": module_name,
+            "flow_module": module_name,
             "flow_function_name": flow_name,
         }
     
@@ -282,7 +282,7 @@ def test_deploy_cli_ship_characterization(monkeypatch, tmp_path, install_prefect
         flow_obj = getattr(flow_module, flow_name)
         filtered[flow_key] = {
             "flow_obj": flow_obj,
-            "module_name": module_name,
+            "flow_module": module_name,
             "flow_function_name": flow_name,
         }
     

--- a/tests/deployment/test_deploy_ship_cloud.py
+++ b/tests/deployment/test_deploy_ship_cloud.py
@@ -144,6 +144,7 @@ def test_deploy_cli_cloud_characterization(monkeypatch, tmp_path, install_prefec
         filtered[flow_key] = {
             "flow_obj": flow_obj,
             "module_name": module_name,
+            "flow_attr_name": flow_name,
             "flow_module": flow_module,
             "entrypoint": entrypoint,
         }
@@ -162,8 +163,8 @@ def test_deploy_cli_cloud_characterization(monkeypatch, tmp_path, install_prefec
     )
 
     expected_entrypoints = {
-        "ingest_haul": "echodataflow/flows/flows_biology.py:flow_ingest_haul",
-        "ingest_NASC": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
+        "ingest_haul": "echodataflow/flows/flows_helper.py:flow_emit_events_wrapper",
+        "ingest_NASC": "echodataflow/flows/flows_helper.py:flow_emit_events_wrapper",
         "update_grid": "echodataflow/flows/flows_integration.py:flow_update_grid",
         "update_cache_MVBS": "echodataflow/flows/flows_viz_cloud.py:flow_update_cache_MVBS",
     }
@@ -289,6 +290,7 @@ def test_deploy_cli_ship_characterization(monkeypatch, tmp_path, install_prefect
         filtered[flow_key] = {
             "flow_obj": flow_obj,
             "module_name": module_name,
+            "flow_attr_name": flow_name,
             "flow_module": flow_module,
             "entrypoint": entrypoint,
         }

--- a/tests/deployment/test_deploy_ship_cloud.py
+++ b/tests/deployment/test_deploy_ship_cloud.py
@@ -162,10 +162,10 @@ def test_deploy_cli_cloud_characterization(monkeypatch, tmp_path, install_prefec
     )
 
     expected_entrypoints = {
-        "ingest_haul": "echodataflow/flows/flows_helper.py:flow_emit_events_wrapper",
-        "ingest_NASC": "echodataflow/flows/flows_helper.py:flow_emit_events_wrapper",
-        "update_grid": "echodataflow/flows/flows_integration.py:flow_update_grid",
-        "update_cache_MVBS": "echodataflow/flows/flows_viz_cloud.py:flow_update_cache_MVBS",
+        "ingest_haul": "echodataflow/flows/flows_helper.py:flow_deployment_wrapper",
+        "ingest_NASC": "echodataflow/flows/flows_helper.py:flow_deployment_wrapper",
+        "update_grid": "echodataflow/flows/flows_helper.py:flow_deployment_wrapper",
+        "update_cache_MVBS": "echodataflow/flows/flows_helper.py:flow_deployment_wrapper",
     }
     actual_entrypoints = {
         item["flow_name"].removeprefix("flow_"): item["entrypoint"]
@@ -305,10 +305,10 @@ def test_deploy_cli_ship_characterization(monkeypatch, tmp_path, install_prefect
     )
 
     expected_entrypoints = {
-        "raw2Sv": "echodataflow/flows/flows_acoustics.py:flow_raw2Sv",
-        "create_MVBS": "echodataflow/flows/flows_acoustics.py:flow_create_MVBS",
-        "predict_hake": "echodataflow/flows/flows_acoustics.py:flow_predict_hake",
-        "file_upload": "echodataflow/flows/flows_helper.py:flow_file_upload",
+        "raw2Sv": "echodataflow/flows/flows_helper.py:flow_deployment_wrapper",
+        "create_MVBS": "echodataflow/flows/flows_helper.py:flow_deployment_wrapper",
+        "predict_hake": "echodataflow/flows/flows_helper.py:flow_deployment_wrapper",
+        "file_upload": "echodataflow/flows/flows_helper.py:flow_deployment_wrapper",
     }
     actual_entrypoints = {
         item["flow_name"].removeprefix("flow_"): item["entrypoint"]

--- a/tests/deployment/test_deploy_ship_cloud.py
+++ b/tests/deployment/test_deploy_ship_cloud.py
@@ -154,7 +154,6 @@ def test_deploy_cli_cloud_characterization(monkeypatch, tmp_path, install_prefec
     module._run_from_specs(
         param_cfg_path=Path("config_cloud.yaml"),
         deploy_cfg_path=Path("deploy_cloud.yaml"),
-        run_concurrency_setup=False,
         default_work_pool_name="local",
     )
 
@@ -294,7 +293,6 @@ def test_deploy_cli_ship_characterization(monkeypatch, tmp_path, install_prefect
     module._run_from_specs(
         param_cfg_path=Path("config_ship.yaml"),
         deploy_cfg_path=Path("deploy_ship.yaml"),
-        run_concurrency_setup=False,
         default_work_pool_name="local",
     )
 

--- a/tests/deployment/test_deploy_ship_cloud.py
+++ b/tests/deployment/test_deploy_ship_cloud.py
@@ -88,17 +88,14 @@ def test_deploy_cli_cloud_characterization(monkeypatch, tmp_path, install_prefec
         "default_work_pool_name": "local",
         "flows": {
             "ingest_haul": {
-                "module": "flows_biology",
                 "deployment_name": "ingest_haul",
                 "interval": 5,
             },
             "ingest_NASC": {
-                "module": "flows_integration",
                 "deployment_name": "ingest_NASC",
                 "interval": 7,
             },
             "update_grid": {
-                "module": "flows_integration",
                 "deployment_name": "update_grid",
                 "triggers": [
                     {
@@ -112,7 +109,6 @@ def test_deploy_cli_cloud_characterization(monkeypatch, tmp_path, install_prefec
                 ],
             },
             "update_cache_MVBS": {
-                "module": "flows_viz_cloud",
                 "deployment_name": "update_cache_MVBS",
                 "interval": 10,
                 "cron_offset": 3,
@@ -138,8 +134,14 @@ def test_deploy_cli_cloud_characterization(monkeypatch, tmp_path, install_prefec
     # Create the filtered flows mapping
     cloud_deploy_cfg = clone_config(deploy_cfg)
     filtered = {}
+    cloud_modules = {
+        "ingest_haul": "flows_biology",
+        "ingest_NASC": "flows_integration",
+        "update_grid": "flows_integration",
+        "update_cache_MVBS": "flows_viz_cloud",
+    }
     for flow_key in cloud_deploy_cfg["flows"].keys():
-        module_name = cloud_deploy_cfg["flows"][flow_key]["module"]
+        module_name = cloud_modules[flow_key]
         flow_alias = cloud_deploy_cfg["flows"][flow_key].get("flow_alias") or flow_key
         flow_name = f"flow_{flow_alias}"
         flow_module = sys.modules[f"echodataflow.flows.{module_name}"]
@@ -233,32 +235,27 @@ def test_deploy_cli_ship_characterization(monkeypatch, tmp_path, install_prefect
         "default_work_pool_name": "local",
         "flows": {
             "raw2Sv": {
-                "module": "flows_acoustics",
                 "deployment_name": "raw2Sv_leg2",
                 "interval": 5,
             },
             "create_MVBS": {
-                "module": "flows_acoustics",
                 "deployment_name": "create-MVBS_leg2",
                 "interval": 10,
                 "cron_offset": 3,
                 "inject_time_offset": True,
             },
             "predict_hake": {
-                "module": "flows_acoustics",
                 "deployment_name": "predict-hake_leg2",
                 "interval": 20,
                 "inject_time_offset": True,
             },
             "file_upload_acoustics": {
-                "module": "flows_helper",
                 "deployment_name": "file-upload-acoustics_leg2",
                 "flow_alias": "file_upload",
                 "interval": 10,
                 "work_pool_name": "local",
             },
             "file_upload_trawl": {
-                "module": "flows_helper",
                 "deployment_name": "file-upload-trawl_20250902",
                 "flow_alias": "file_upload",
                 "interval": 10,
@@ -284,8 +281,15 @@ def test_deploy_cli_ship_characterization(monkeypatch, tmp_path, install_prefect
     # Create the filtered flows mapping
     ship_deploy_cfg = clone_config(deploy_cfg)
     filtered = {}
+    ship_modules = {
+        "raw2Sv": "flows_acoustics",
+        "create_MVBS": "flows_acoustics",
+        "predict_hake": "flows_acoustics",
+        "file_upload_acoustics": "flows_helper",
+        "file_upload_trawl": "flows_helper",
+    }
     for flow_key in ship_deploy_cfg["flows"].keys():
-        module_name = ship_deploy_cfg["flows"][flow_key]["module"]
+        module_name = ship_modules[flow_key]
         flow_alias = ship_deploy_cfg["flows"][flow_key].get("flow_alias") or flow_key
         flow_name = f"flow_{flow_alias}"
         flow_module = sys.modules[f"echodataflow.flows.{module_name}"]

--- a/tests/deployment/test_deploy_ship_cloud.py
+++ b/tests/deployment/test_deploy_ship_cloud.py
@@ -140,13 +140,10 @@ def test_deploy_cli_cloud_characterization(monkeypatch, tmp_path, install_prefec
         flow_name = f"flow_{flow_alias}"
         flow_module = sys.modules[f"echodataflow.flows.{module_name}"]
         flow_obj = getattr(flow_module, flow_name)
-        entrypoint = f"echodataflow/flows/{module_name}.py:{flow_name}"
         filtered[flow_key] = {
             "flow_obj": flow_obj,
-            "module_name": module_name,
             "flow_function_name": flow_name,
             "flow_module": flow_module,
-            "entrypoint": entrypoint,
         }
     
     # Mock the discovery functions in the deploy_cli module
@@ -283,13 +280,10 @@ def test_deploy_cli_ship_characterization(monkeypatch, tmp_path, install_prefect
         flow_name = f"flow_{flow_alias}"
         flow_module = sys.modules[f"echodataflow.flows.{module_name}"]
         flow_obj = getattr(flow_module, flow_name)
-        entrypoint = f"echodataflow/flows/{module_name}.py:{flow_name}"
         filtered[flow_key] = {
             "flow_obj": flow_obj,
-            "module_name": module_name,
             "flow_function_name": flow_name,
             "flow_module": flow_module,
-            "entrypoint": entrypoint,
         }
     
     # Mock the discovery functions in the deploy_cli module

--- a/tests/deployment/test_deploy_ship_cloud.py
+++ b/tests/deployment/test_deploy_ship_cloud.py
@@ -144,7 +144,7 @@ def test_deploy_cli_cloud_characterization(monkeypatch, tmp_path, install_prefec
         filtered[flow_key] = {
             "flow_obj": flow_obj,
             "module_name": module_name,
-            "flow_attr_name": flow_name,
+            "flow_function_name": flow_name,
             "flow_module": flow_module,
             "entrypoint": entrypoint,
         }
@@ -287,7 +287,7 @@ def test_deploy_cli_ship_characterization(monkeypatch, tmp_path, install_prefect
         filtered[flow_key] = {
             "flow_obj": flow_obj,
             "module_name": module_name,
-            "flow_attr_name": flow_name,
+            "flow_function_name": flow_name,
             "flow_module": flow_module,
             "entrypoint": entrypoint,
         }

--- a/tests/deployment/test_deploy_ship_cloud.py
+++ b/tests/deployment/test_deploy_ship_cloud.py
@@ -91,20 +91,24 @@ def test_deploy_cli_cloud_characterization(monkeypatch, tmp_path, install_prefec
                 "module": "flows_biology",
                 "deployment_name": "ingest_haul",
                 "interval": 5,
-                "emit_events": ["haul.ingested"],
             },
             "ingest_NASC": {
                 "module": "flows_integration",
                 "deployment_name": "ingest_NASC",
                 "interval": 7,
-                "emit_events": ["nasc.ingested"],
             },
             "update_grid": {
                 "module": "flows_integration",
                 "deployment_name": "update_grid",
                 "triggers": [
-                    {"expect": "haul.ingested", "resource_name": "ingest_haul"},
-                    {"expect": "nasc.ingested", "resource_name": "ingest_NASC"},
+                    {
+                        "expect": "prefect.flow-run.Completed",
+                        "resource_name": "ingest_haul",
+                    },
+                    {
+                        "expect": "prefect.flow-run.Completed",
+                        "resource_name": "ingest_NASC",
+                    },
                 ],
             },
             "update_cache_MVBS": {
@@ -158,10 +162,10 @@ def test_deploy_cli_cloud_characterization(monkeypatch, tmp_path, install_prefec
     )
 
     expected_entrypoints = {
-        "ingest_haul": "echodataflow/flows/flows_helper.py:flow_deployment_wrapper",
-        "ingest_NASC": "echodataflow/flows/flows_helper.py:flow_deployment_wrapper",
-        "update_grid": "echodataflow/flows/flows_helper.py:flow_deployment_wrapper",
-        "update_cache_MVBS": "echodataflow/flows/flows_helper.py:flow_deployment_wrapper",
+        "ingest_haul": "echodataflow/flows/flows_biology.py:flow_ingest_haul",
+        "ingest_NASC": "echodataflow/flows/flows_integration.py:flow_ingest_NASC",
+        "update_grid": "echodataflow/flows/flows_integration.py:flow_update_grid",
+        "update_cache_MVBS": "echodataflow/flows/flows_viz_cloud.py:flow_update_cache_MVBS",
     }
     actual_entrypoints = {
         item["flow_name"].removeprefix("flow_"): item["entrypoint"]
@@ -180,13 +184,20 @@ def test_deploy_cli_cloud_characterization(monkeypatch, tmp_path, install_prefec
 
     update_grid = next(d for d in sink["deployments"] if d["name"] == "update_grid")
     assert len(update_grid["triggers"]) == 2
+    assert update_grid["triggers"][0].kwargs == {
+        "expect": {"prefect.flow-run.Completed"},
+        "match_related": {
+            "prefect.resource.name": "ingest_haul",
+            "prefect.resource.role": "deployment",
+        },
+    }
 
     ingest_haul = next(d for d in sink["deployments"] if d["name"] == "ingest_haul")
     ingest_nasc = next(d for d in sink["deployments"] if d["name"] == "ingest_NASC")
     assert ingest_haul["cron"] == "*/5 * * * *"
     assert ingest_nasc["cron"] == "*/7 * * * *"
-    assert ingest_haul["parameters"]["emit_events"] == ["haul.ingested"]
-    assert ingest_nasc["parameters"]["emit_events"] == ["nasc.ingested"]
+    assert ingest_haul["parameters"] == {"x": 1}
+    assert ingest_nasc["parameters"] == {"y": 2}
 
 
 
@@ -297,10 +308,10 @@ def test_deploy_cli_ship_characterization(monkeypatch, tmp_path, install_prefect
     )
 
     expected_entrypoints = {
-        "raw2Sv": "echodataflow/flows/flows_helper.py:flow_deployment_wrapper",
-        "create_MVBS": "echodataflow/flows/flows_helper.py:flow_deployment_wrapper",
-        "predict_hake": "echodataflow/flows/flows_helper.py:flow_deployment_wrapper",
-        "file_upload": "echodataflow/flows/flows_helper.py:flow_deployment_wrapper",
+        "raw2Sv": "echodataflow/flows/flows_acoustics.py:flow_raw2Sv",
+        "create_MVBS": "echodataflow/flows/flows_acoustics.py:flow_create_MVBS",
+        "predict_hake": "echodataflow/flows/flows_acoustics.py:flow_predict_hake",
+        "file_upload": "echodataflow/flows/flows_helper.py:flow_file_upload",
     }
     actual_entrypoints = {
         item["flow_name"].removeprefix("flow_"): item["entrypoint"]

--- a/tests/deployment/test_deploy_ship_cloud.py
+++ b/tests/deployment/test_deploy_ship_cloud.py
@@ -91,11 +91,13 @@ def test_deploy_cli_cloud_characterization(monkeypatch, tmp_path, install_prefec
                 "module": "flows_biology",
                 "deployment_name": "ingest_haul",
                 "interval": 5,
+                "emit_events": ["haul.ingested"],
             },
             "ingest_NASC": {
                 "module": "flows_integration",
                 "deployment_name": "ingest_NASC",
                 "interval": 7,
+                "emit_events": ["nasc.ingested"],
             },
             "update_grid": {
                 "module": "flows_integration",
@@ -187,6 +189,8 @@ def test_deploy_cli_cloud_characterization(monkeypatch, tmp_path, install_prefec
     ingest_nasc = next(d for d in sink["deployments"] if d["name"] == "ingest_NASC")
     assert ingest_haul["cron"] == "*/5 * * * *"
     assert ingest_nasc["cron"] == "*/7 * * * *"
+    assert ingest_haul["parameters"]["emit_events"] == ["haul.ingested"]
+    assert ingest_nasc["parameters"]["emit_events"] == ["nasc.ingested"]
 
 
 

--- a/tests/deployment/test_deploy_ship_cloud.py
+++ b/tests/deployment/test_deploy_ship_cloud.py
@@ -142,8 +142,8 @@ def test_deploy_cli_cloud_characterization(monkeypatch, tmp_path, install_prefec
         flow_obj = getattr(flow_module, flow_name)
         filtered[flow_key] = {
             "flow_obj": flow_obj,
+            "module_name": module_name,
             "flow_function_name": flow_name,
-            "flow_module": flow_module,
         }
     
     # Mock the discovery functions in the deploy_cli module
@@ -282,8 +282,8 @@ def test_deploy_cli_ship_characterization(monkeypatch, tmp_path, install_prefect
         flow_obj = getattr(flow_module, flow_name)
         filtered[flow_key] = {
             "flow_obj": flow_obj,
+            "module_name": module_name,
             "flow_function_name": flow_name,
-            "flow_module": flow_module,
         }
     
     # Mock the discovery functions in the deploy_cli module


### PR DESCRIPTION
This PR:
- cleans up redundancy in `deploy_cli` and related functions
- switches to use Prefect native emitted event at flow completion as trigger (this closes #160)
- removes `--source-mode` as an argument for `deploy_cli` and using only recipe to config code source
- removes `apply_separately` and now deployment is standalone only when work pool is not the default one
- cleans up `build_deploy_specs` so it focuses on validating and compiling parameters needed for deployment
- cleans up `create_deployments` so that it just deploys what's been built in `build_deploy_speces` to Prefect
- removes all concurrency limit handling -- will take this on another time (tracked in #166)
