### PR TITLE
Add post-processing flows for the edge components

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,6 @@ dependencies = [
     "boto3",
     "bokeh",
     "cartopy",
-    # "echopype>=0.11.0",
-    # "echoshader",
     "geopandas",
     "geopy",
     "geoviews",
@@ -55,6 +53,11 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
+mission = [
+    "echopype",
+    "echoshader",
+    "opencv",
+]
 notebook = [
     "ipykernel",
 ]

--- a/src/echodataflow/deployment/core.py
+++ b/src/echodataflow/deployment/core.py
@@ -1,14 +1,30 @@
 DEFAULT_ENTRYPOINT_ROOT = "echodataflow/flows"
 
-ALLOWED_DEPLOY_KEYS = {"flow_start_time", "default_work_pool_name", "source", "flows"}
+ALLOWED_DEPLOY_KEYS = {
+    "concurrency_groups",
+    "flow_start_time",
+    "default_work_pool_name",
+    "source",
+    "flows",
+}
 ALLOWED_FLOW_DEPLOY_KEYS = {
+    "concurrency_group",
     "deployment_name",
     "flow",
     "interval",
     "cron_offset",
     "triggers",
     "inject_time_offset",
+    "task_runner",
     "work_pool_name",
+}
+ALLOWED_CONCURRENCY_GROUP_KEYS = {"limit"}
+ALLOWED_TASK_RUNNER_KEYS = {"type", "cluster_kwargs"}
+ALLOWED_DASK_CLUSTER_KEYS = {
+    "memory_limit",
+    "n_workers",
+    "processes",
+    "threads_per_worker",
 }
 ALLOWED_TRIGGER_KEYS = {"expect", "resource_name"}
 ALLOWED_SOURCE_KEYS = {"mode", "git"}

--- a/src/echodataflow/deployment/core.py
+++ b/src/echodataflow/deployment/core.py
@@ -1,4 +1,5 @@
 DEFAULT_ENTRYPOINT_ROOT = "echodataflow/flows"
+TASK_RUNNER_ENV_VAR = "ECHODATAFLOW_TASK_RUNNER"
 
 ALLOWED_DEPLOY_KEYS = {
     "concurrency_groups",

--- a/src/echodataflow/deployment/deploy_cli.py
+++ b/src/echodataflow/deployment/deploy_cli.py
@@ -32,6 +32,8 @@ def _run_from_specs(
     # Validate the deployment schema and paired flow coverage.
     validate_deploy_config(deploy_cfg)
     validate_flow_coverage(param_cfg, deploy_cfg)
+    if deploy_cfg.get("flow_start_time") is not None:
+        print(f"Time travel mode: flow start time is {deploy_cfg['flow_start_time']}")
 
     # Validate registry keys and import only the flows requested by this recipe.
     resolved_flows = resolve_registered_flows(deploy_cfg)

--- a/src/echodataflow/deployment/deploy_cli.py
+++ b/src/echodataflow/deployment/deploy_cli.py
@@ -6,7 +6,6 @@ import argparse
 from pathlib import Path
 
 from prefect import deploy
-from prefect.variables import Variable
 
 from echodataflow.deployment.deployment_engine import (
     build_deploy_specs,
@@ -33,9 +32,6 @@ def _run_from_specs(
     # Validate the deployment schema and paired flow coverage.
     validate_deploy_config(deploy_cfg)
     validate_flow_coverage(param_cfg, deploy_cfg)
-
-    # Set "flow_start_time" as a Prefect variable
-    Variable.set("flow_start_time", deploy_cfg.get("flow_start_time"), overwrite=True)
 
     # Validate registry keys and import only the flows requested by this recipe.
     resolved_flows = resolve_registered_flows(deploy_cfg)

--- a/src/echodataflow/deployment/deploy_cli.py
+++ b/src/echodataflow/deployment/deploy_cli.py
@@ -10,6 +10,7 @@ from prefect.variables import Variable
 
 from echodataflow.deployment.deployment_engine import (
     build_deploy_specs,
+    configure_concurrency_groups,
     create_deployments,
     load_config,
     resolve_registered_flows,
@@ -54,6 +55,11 @@ def _run_from_specs(
         deploy_cfg=deploy_cfg,
         resolved_flows=resolved_flows,
     )
+    configure_concurrency_groups(
+        specs=specs,
+        concurrency_groups=deploy_cfg.get("concurrency_groups", {}),
+        default_work_pool_name=default_work_pool_name,
+    )
     grouped, standalone = create_deployments(
         specs=specs,
         source=source,
@@ -80,9 +86,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--default-work-pool-name",
         required=True,
         default="local",
-        help=(
-            "Default work pool name for deployments."
-        ),
+        help="Default work pool name for deployments.",
     )
     run_parser.add_argument(
         "--param-config",

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -26,8 +26,8 @@ from echodataflow.deployment.core import (
     ALLOWED_TASK_RUNNER_KEYS,
     ALLOWED_TRIGGER_KEYS,
     DEFAULT_ENTRYPOINT_ROOT,
+    TASK_RUNNER_ENV_VAR,
 )
-from echodataflow.deployment.task_runners import TASK_RUNNER_ENV_VAR
 
 
 @dataclass(frozen=True)

--- a/src/echodataflow/deployment/deployment_engine.py
+++ b/src/echodataflow/deployment/deployment_engine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime
 import importlib.util
 import inspect
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -16,24 +17,34 @@ from prefect.variables import Variable
 from yaml import safe_load
 
 from echodataflow.deployment.core import (
+    ALLOWED_CONCURRENCY_GROUP_KEYS,
+    ALLOWED_DASK_CLUSTER_KEYS,
     ALLOWED_DEPLOY_KEYS,
     ALLOWED_FLOW_DEPLOY_KEYS,
     ALLOWED_GIT_SOURCE_KEYS,
     ALLOWED_SOURCE_KEYS,
+    ALLOWED_TASK_RUNNER_KEYS,
     ALLOWED_TRIGGER_KEYS,
     DEFAULT_ENTRYPOINT_ROOT,
 )
+from echodataflow.deployment.task_runners import TASK_RUNNER_ENV_VAR
 
 
 @dataclass(frozen=True)
 class DeploymentSpec:
-    flow_key: str  # the flow key from deploy config, used to look up flow params and deploy settings
+    flow_key: (
+        str  # the flow key from deploy config, used to look up flow params and deploy settings
+    )
     deployment_name: str  # the deployment name to use for this flow
     flow_obj: Flow[..., Any]  # the actual Flow object resolved from the registry
     entrypoint: str  # source-relative entrypoint for the actual deployed flow
     parameters: dict[str, Any]  # parameters passed directly to the deployed flow
+    concurrency_group: str | None = None
+    task_runner: dict[str, Any] | None = None
     cron: str | None = None  # precomputed cron schedule, when interval mode is used
-    work_pool_name: str | None = None  # the work pool name to use for this deployment, if different from default
+    work_pool_name: str | None = (
+        None  # the work pool name to use for this deployment, if different from default
+    )
     triggers: list[Any] | None = None  # precomputed Prefect trigger objects
 
 
@@ -50,9 +61,7 @@ def resolve_registered_flows(
 
         registry_key = deploy_meta.get("flow", recipe_key)
         if not isinstance(registry_key, str) or not registry_key.strip():
-            raise ValueError(
-                f"deploy_cfg.flows.{recipe_key}.flow must be a non-empty string"
-            )
+            raise ValueError(f"deploy_cfg.flows.{recipe_key}.flow must be a non-empty string")
         registry_key = registry_key.strip()
 
         try:
@@ -75,9 +84,7 @@ def resolve_registered_flows(
         try:
             flow_module_obj = importlib.import_module(module_name)
         except ImportError as e:
-            raise ImportError(
-                f"Failed to import registered flow module {module_name}: {e}"
-            ) from e
+            raise ImportError(f"Failed to import registered flow module {module_name}: {e}") from e
 
         try:
             flow_obj = cast(Flow[..., Any], getattr(flow_module_obj, function_name))
@@ -122,7 +129,7 @@ def _infer_local_source_root() -> Path:
 
 def _validate_local_source_layout(local_source_root: Path) -> Path:
     """
-    Validate the local source root and entrypoint exists 
+    Validate the local source root and entrypoint exists
     and return the root to use for local deployments.
     """
     root = local_source_root.resolve()
@@ -206,10 +213,9 @@ def _compute_time_offset_seconds(flow_start_time: str | None) -> float:
     if flow_start_time is None:
         return 0.0
 
-    curr_time_offset = (
-        datetime.datetime.now(datetime.timezone.utc)
-        - datetime.datetime.fromisoformat(flow_start_time).astimezone(datetime.timezone.utc)
-    )
+    curr_time_offset = datetime.datetime.now(
+        datetime.timezone.utc
+    ) - datetime.datetime.fromisoformat(flow_start_time).astimezone(datetime.timezone.utc)
     return curr_time_offset.total_seconds()
 
 
@@ -245,6 +251,35 @@ def _reject_unknown_keys(
         raise ValueError(f"Unsupported field(s) at {path}: {unknown}")
 
 
+def _validate_positive_integer(value: Any, *, path: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{path} must be a positive integer")
+
+
+def validate_task_runner_config(value: Any, *, path: str) -> None:
+    """Validate the supported YAML representation of a task runner."""
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must be a mapping")
+    _reject_unknown_keys(value, allowed=ALLOWED_TASK_RUNNER_KEYS, path=path)
+    if value.get("type") != "dask":
+        raise ValueError(f"{path}.type must be 'dask'")
+
+    cluster_kwargs = value.get("cluster_kwargs", {})
+    cluster_path = f"{path}.cluster_kwargs"
+    if not isinstance(cluster_kwargs, dict):
+        raise ValueError(f"{cluster_path} must be a mapping")
+    _reject_unknown_keys(
+        cluster_kwargs,
+        allowed=ALLOWED_DASK_CLUSTER_KEYS,
+        path=cluster_path,
+    )
+    for key in ("n_workers", "threads_per_worker"):
+        if key in cluster_kwargs:
+            _validate_positive_integer(cluster_kwargs[key], path=f"{cluster_path}.{key}")
+    if "processes" in cluster_kwargs and not isinstance(cluster_kwargs["processes"], bool):
+        raise ValueError(f"{cluster_path}.processes must be a boolean")
+
+
 def validate_deploy_config(deploy_cfg: Any) -> None:
     """Reject unknown fields throughout a deployment specification."""
     if not isinstance(deploy_cfg, dict):
@@ -255,6 +290,24 @@ def validate_deploy_config(deploy_cfg: Any) -> None:
     flows = deploy_cfg.get("flows")
     if not isinstance(flows, dict):
         raise ValueError("deploy_cfg.flows must be a mapping")
+
+    concurrency_groups = deploy_cfg.get("concurrency_groups", {})
+    if not isinstance(concurrency_groups, dict):
+        raise ValueError("deploy_cfg.concurrency_groups must be a mapping")
+    for group_name, group_config in concurrency_groups.items():
+        group_path = f"deploy_cfg.concurrency_groups.{group_name}"
+        if not isinstance(group_name, str) or not group_name.strip():
+            raise ValueError("deploy_cfg.concurrency_groups keys must be non-empty strings")
+        if not isinstance(group_config, dict):
+            raise ValueError(f"{group_path} must be a mapping")
+        _reject_unknown_keys(
+            group_config,
+            allowed=ALLOWED_CONCURRENCY_GROUP_KEYS,
+            path=group_path,
+        )
+        if "limit" not in group_config:
+            raise ValueError(f"{group_path}.limit is required")
+        _validate_positive_integer(group_config["limit"], path=f"{group_path}.limit")
 
     for flow_key, deploy_meta in flows.items():
         flow_path = f"deploy_cfg.flows.{flow_key}"
@@ -271,6 +324,20 @@ def validate_deploy_config(deploy_cfg: Any) -> None:
             not isinstance(registry_key, str) or not registry_key.strip()
         ):
             raise ValueError(f"{flow_path}.flow must be a non-empty string")
+
+        concurrency_group = deploy_meta.get("concurrency_group")
+        if concurrency_group is not None:
+            if not isinstance(concurrency_group, str) or not concurrency_group.strip():
+                raise ValueError(f"{flow_path}.concurrency_group must be a non-empty string")
+            if concurrency_group not in concurrency_groups:
+                raise ValueError(
+                    f"{flow_path}.concurrency_group references undefined group "
+                    f"{concurrency_group!r}"
+                )
+
+        task_runner = deploy_meta.get("task_runner")
+        if task_runner is not None:
+            validate_task_runner_config(task_runner, path=f"{flow_path}.task_runner")
 
         triggers = deploy_meta.get("triggers")
         if isinstance(triggers, list):
@@ -341,9 +408,7 @@ def validate_triggers(
     validated_triggers: list[dict[str, Any]] = []
     for trigger_item in triggers:
         if not isinstance(trigger_item, dict):
-            raise ValueError(
-                f"deploy_cfg.flows.{flow_key}.triggers entries must be mappings"
-            )
+            raise ValueError(f"deploy_cfg.flows.{flow_key}.triggers entries must be mappings")
 
         expect = trigger_item.get("expect")
         resource_name = trigger_item.get("resource_name")
@@ -385,13 +450,9 @@ def validate_flow_coverage(
     missing_from_config = deploy_flow_keys - config_flows
     errors: list[str] = []
     if missing_from_deploy:
-        errors.append(
-            f"In config but missing from deploy: {sorted(missing_from_deploy)}"
-        )
+        errors.append(f"In config but missing from deploy: {sorted(missing_from_deploy)}")
     if missing_from_config:
-        errors.append(
-            f"In deploy but missing from config: {sorted(missing_from_config)}"
-        )
+        errors.append(f"In deploy but missing from config: {sorted(missing_from_config)}")
     if errors:
         raise ValueError("Flow coverage mismatch. " + " | ".join(errors))
 
@@ -435,9 +496,8 @@ def build_deploy_specs(
         flow_info = resolved_flows[key]
 
         # Check if time_offset_seconds is indeed accepted by the flows specified in deploy config
-        if (
-            key in time_offset_targets
-            and not _flow_accepts_time_offset_seconds(flow_info["flow_obj"])
+        if key in time_offset_targets and not _flow_accepts_time_offset_seconds(
+            flow_info["flow_obj"]
         ):
             raise ValueError(
                 f"deploy_cfg.flows.{key}.inject_time_offset is enabled, "
@@ -446,9 +506,7 @@ def build_deploy_specs(
 
         # Scheduling is optional for manually run deployments, but the two
         # supported scheduling mechanisms are mutually exclusive.
-        if (deploy_meta.get("triggers") is not None) and (
-            deploy_meta.get("interval") is not None
-        ):
+        if (deploy_meta.get("triggers") is not None) and (deploy_meta.get("interval") is not None):
             raise ValueError(
                 f"deploy_cfg.flows.{key} must define only one of 'triggers' or 'interval'"
             )
@@ -468,9 +526,7 @@ def build_deploy_specs(
         # Build deployment_parameters
         flow_params = flows_params.get(key)
         if not isinstance(flow_params, dict):
-            raise ValueError(
-                f"param_cfg.flows.{key} must be a mapping of flow parameters"
-            )
+            raise ValueError(f"param_cfg.flows.{key} must be a mapping of flow parameters")
 
         deployment_parameters = dict(flow_params)
         if key in time_offset_targets:
@@ -483,6 +539,8 @@ def build_deploy_specs(
                 flow_obj=flow_info["flow_obj"],
                 entrypoint=flow_info["entrypoint"],
                 parameters=deployment_parameters,
+                concurrency_group=deploy_meta.get("concurrency_group"),
+                task_runner=deploy_meta.get("task_runner"),
                 cron=cron,
                 work_pool_name=deploy_meta.get("work_pool_name"),
                 triggers=compiled_triggers,
@@ -521,12 +579,21 @@ def create_deployments(
         if has_non_default_work_pool:
             deployment_kwargs["work_pool_name"] = spec.work_pool_name
 
-        deployment = (
-            flow_obj.from_source(
-                source=source,
-                entrypoint=spec.entrypoint,
-            ).to_deployment(**deployment_kwargs)
+        if spec.concurrency_group is not None:
+            deployment_kwargs["work_queue_name"] = spec.concurrency_group
+
+        # The worker reloads the flow entrypoint, so runner settings must be
+        # present in its runtime environment instead of only on this Flow object
+        if spec.task_runner is not None:
+            deployment_kwargs["job_variables"] = {
+                "env": {TASK_RUNNER_ENV_VAR: json.dumps(spec.task_runner)}
+            }
+
+        sourced_flow = flow_obj.from_source(
+            source=source,
+            entrypoint=spec.entrypoint,
         )
+        deployment = sourced_flow.to_deployment(**deployment_kwargs)
 
         if has_non_default_work_pool:
             standalone.append(deployment)
@@ -534,3 +601,46 @@ def create_deployments(
             grouped.append(deployment)
 
     return grouped, standalone
+
+
+def configure_concurrency_groups(
+    *,
+    specs: list[DeploymentSpec],
+    concurrency_groups: dict[str, dict[str, Any]],
+    default_work_pool_name: str,
+) -> None:
+    """Create or update shared, concurrency-limited Prefect work queues."""
+    if not concurrency_groups:
+        return
+
+    from prefect.client.orchestration import get_client
+    from prefect.exceptions import ObjectNotFound
+
+    with get_client(sync_client=True) as client:
+        for group_name, group_config in concurrency_groups.items():
+            members = [spec for spec in specs if spec.concurrency_group == group_name]
+            if not members:
+                continue
+
+            work_pools = {spec.work_pool_name or default_work_pool_name for spec in members}
+            if len(work_pools) != 1:
+                raise ValueError(
+                    f"Concurrency group {group_name!r} spans multiple work pools: "
+                    f"{sorted(work_pools)}"
+                )
+            work_pool_name = work_pools.pop()
+            limit = group_config["limit"]
+
+            try:
+                queue = client.read_work_queue_by_name(
+                    group_name,
+                    work_pool_name=work_pool_name,
+                )
+            except ObjectNotFound:
+                client.create_work_queue(
+                    name=group_name,
+                    concurrency_limit=limit,
+                    work_pool_name=work_pool_name,
+                )
+            else:
+                client.update_work_queue(queue.id, concurrency_limit=limit)

--- a/src/echodataflow/deployment/flow_registry.py
+++ b/src/echodataflow/deployment/flow_registry.py
@@ -24,6 +24,27 @@ FLOW_REGISTRY: dict[str, FlowRegistration] = {
     "predict_hake": FlowRegistration(
         entrypoint="echodataflow/flows/flow_predict_hake.py:flow_predict_hake",
     ),
+    "raw2Sv_postprocessing": FlowRegistration(
+        entrypoint=(
+            "echodataflow/flows/flows_acoustics.py:"
+            "flow_raw2Sv_postprocessing"
+        ),
+        description="Convert a historical S3 raw-file manifest to Sv incrementally.",
+    ),
+    "create_MVBS_postprocessing": FlowRegistration(
+        entrypoint=(
+            "echodataflow/flows/flows_acoustics.py:"
+            "flow_create_MVBS_postprocessing"
+        ),
+        description="Create all newly ready historical MVBS slices.",
+    ),
+    "predict_hake_postprocessing": FlowRegistration(
+        entrypoint=(
+            "echodataflow/flows/flow_predict_hake.py:"
+            "flow_predict_hake_postprocessing"
+        ),
+        description="Predict all newly ready historical MVBS windows.",
+    ),
     "ingest_haul": FlowRegistration(
         entrypoint="echodataflow/flows/flows_biology.py:flow_ingest_haul",
     ),

--- a/src/echodataflow/deployment/flow_registry.py
+++ b/src/echodataflow/deployment/flow_registry.py
@@ -22,7 +22,7 @@ FLOW_REGISTRY: dict[str, FlowRegistration] = {
         entrypoint="echodataflow/flows/flows_acoustics.py:flow_create_MVBS",
     ),
     "predict_hake": FlowRegistration(
-        entrypoint="echodataflow/flows/flow_predict_hake.py:flow_predict_hake",
+        entrypoint="echodataflow/flows/flows_predict_hake.py:flow_predict_hake",
     ),
     "raw2Sv_postprocessing": FlowRegistration(
         entrypoint=(
@@ -40,7 +40,7 @@ FLOW_REGISTRY: dict[str, FlowRegistration] = {
     ),
     "predict_hake_postprocessing": FlowRegistration(
         entrypoint=(
-            "echodataflow/flows/flow_predict_hake.py:"
+            "echodataflow/flows/flows_predict_hake.py:"
             "flow_predict_hake_postprocessing"
         ),
         description="Predict all newly ready historical MVBS windows.",

--- a/src/echodataflow/deployment/task_runners.py
+++ b/src/echodataflow/deployment/task_runners.py
@@ -1,0 +1,22 @@
+"""Runtime task-runner configuration supplied by deployment job variables."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from prefect_dask import DaskTaskRunner
+
+TASK_RUNNER_ENV_VAR = "ECHODATAFLOW_TASK_RUNNER"
+
+
+def dask_task_runner_from_environment() -> DaskTaskRunner:
+    """Build the flow's Dask runner when its entrypoint is loaded by a worker."""
+    serialized = os.getenv(TASK_RUNNER_ENV_VAR)
+    if serialized is None:
+        return DaskTaskRunner()
+
+    config = json.loads(serialized)
+    if config.get("type") != "dask":
+        raise ValueError(f"{TASK_RUNNER_ENV_VAR}.type must be 'dask'")
+    return DaskTaskRunner(cluster_kwargs=dict(config.get("cluster_kwargs", {})))

--- a/src/echodataflow/deployment/task_runners.py
+++ b/src/echodataflow/deployment/task_runners.py
@@ -7,7 +7,7 @@ import os
 
 from prefect_dask import DaskTaskRunner
 
-TASK_RUNNER_ENV_VAR = "ECHODATAFLOW_TASK_RUNNER"
+from echodataflow.deployment.core import TASK_RUNNER_ENV_VAR
 
 
 def dask_task_runner_from_environment() -> DaskTaskRunner:

--- a/src/echodataflow/flows/flow_predict_hake.py
+++ b/src/echodataflow/flows/flow_predict_hake.py
@@ -10,6 +10,14 @@ import pandas as pd
 from prefect import flow, get_client, get_run_logger, runtime
 from prefect.states import Failed
 
+from echodataflow.utils.manifests import (
+    MVBS_COLUMNS,
+    PREDICTION_COLUMNS,
+    filter_slices,
+    read_manifest,
+    write_manifest,
+)
+from echodataflow.operations.operations_postprocessing import plan_prediction_slices
 from echodataflow.operations.operations_predict_hake import (
     ComputeNASCSettings,
     ComputeNASCWorkItem,
@@ -261,3 +269,122 @@ async def flow_predict_hake(
                 flow_run_id=runtime.flow_run.id, state=Failed(message=error_msg)
             )
         raise Exception(error_msg)  # Stop the flow execution
+
+
+@flow(log_prints=True)
+def flow_predict_hake_postprocessing(
+    path_main: str,
+    path_weight: str,
+    mvbs_slice_mins: int = 20,
+    prediction_slice_mins: int = 40,
+    start_time: str | None = None,
+    end_time: str | None = None,
+    require_complete_window: bool = True,
+    overwrite: bool = False,
+    temperature: float = 0.5,
+    softmax_threshold: float = 0.5,
+    max_depth: float = 590.0,
+    nasc_range_bin: str = "10m",
+    nasc_dist_bin: str = "0.5nmi",
+    file_MVBS_csv: str = "MVBS_files.csv",
+    file_prediction_csv: str = "prediction_files.csv",
+) -> None:
+    """Predict all newly ready windows, combining aligned MVBS slices."""
+    logger = get_run_logger()
+    # Create persistent destinations before loading the model
+    for directory in ["prediction", "EVR", "NASC"]:
+        (Path(path_main) / directory).mkdir(parents=True, exist_ok=True)
+    # Load available MVBS slices and prior prediction results for resume behavior
+    mvbs = read_manifest(
+        Path(path_main) / file_MVBS_csv,
+        MVBS_COLUMNS,
+        ["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
+    )
+    manifest_path = Path(path_main) / file_prediction_csv
+    manifest = read_manifest(
+        manifest_path,
+        PREDICTION_COLUMNS,
+        ["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
+    )
+    # Assemble aligned prediction windows from completed MVBS slices
+    planned = filter_slices(
+        plan_prediction_slices(
+            mvbs,
+            mvbs_slice_mins=mvbs_slice_mins,
+            prediction_slice_mins=prediction_slice_mins,
+            require_complete_window=require_complete_window,
+        ),
+        start_time,
+        end_time,
+    )
+    existing = set(manifest["prediction_filename_postfix"]) if not overwrite else set()
+    planned = [
+        item
+        for item in planned
+        if item.start_time.strftime("%Y%m%dT%H%M%S") not in existing
+    ]
+    if not planned:
+        logger.info("No newly ready prediction windows")
+        return
+
+    # Load the model once and reuse it across all ready windows in this flow run
+    model = get_hake_model(path_weight)
+    prediction_settings = PredictHakeSettings(
+        model=model,
+        mvbs_directory=str(Path(path_main) / "MVBS"),
+        prediction_directory=str(Path(path_main) / "prediction"),
+        evr_directory=str(Path(path_main) / "EVR"),
+        temperature=temperature,
+        softmax_threshold=softmax_threshold,
+        max_depth=max_depth,
+    )
+    nasc_settings = ComputeNASCSettings(
+        output_directory=str(Path(path_main) / "NASC"),
+        range_bin=nasc_range_bin,
+        dist_bin=nasc_dist_bin,
+    )
+    # Prediction remains sequential because all windows share the loaded model
+    errors = []
+    for item in planned:
+        postfix = item.start_time.strftime("%Y%m%dT%H%M%S")
+        try:
+            result = task_predict_hake.with_options(task_run_name=f"predict_{postfix}")(
+                PredictHakeWorkItem(
+                    start_time=item.start_time,
+                    end_time=item.end_time,
+                    mvbs_filenames=item.filenames,
+                    filename_postfix=postfix,
+                ),
+                prediction_settings,
+            )
+            # Compute NASC only after the prediction for this window succeeds
+            task_compute_NASC.with_options(task_run_name=f"NASC_{postfix}")(
+                ComputeNASCWorkItem(
+                    nasc_filename=f"NASC_{postfix}.zarr",
+                    prediction=result,
+                ),
+                nasc_settings,
+            )
+            record = [
+                postfix,
+                result.score_filename,
+                result.softmax_filename,
+                result.prediction_filename,
+                result.evr_filename,
+                item.start_time,
+                item.end_time,
+                result.first_ping_time,
+                result.last_ping_time,
+            ]
+            # Persist after each window so a failed later window does not lose progress
+            matches = manifest.index[manifest["prediction_filename_postfix"] == postfix]
+            if len(matches):
+                manifest.loc[matches[0], PREDICTION_COLUMNS] = record
+            else:
+                manifest.loc[len(manifest), PREDICTION_COLUMNS] = record
+            write_manifest(manifest.sort_values("slice_start"), manifest_path)
+        except Exception as exc:
+            errors.append(exc)
+            logger.error("Prediction window %s failed: %s", item.start_time, exc)
+    if errors:
+        raise RuntimeError(f"{len(errors)} prediction windows failed")

--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -33,8 +33,8 @@ from echodataflow.operations.operations_acoustics import (
     RawToSvWorkItem,
 )
 from echodataflow.operations.operations_postprocessing import (
-    build_mvbs_ledger,
-    build_sv_ledger,
+    build_MVBS_ledger,
+    build_Sv_ledger,
     plan_mvbs_slices,
     read_or_create_ledger,
 )
@@ -438,7 +438,7 @@ def flow_raw2Sv_postprocessing(
         ledger_path=file_Sv_csv,
         columns=SV_COLUMNS_POSTPROCESSING,
         date_columns=["timestamp", "first_ping_time", "last_ping_time"],
-        builder=lambda: build_sv_ledger(pd.read_csv(path_raw_list)),
+        builder=lambda: build_Sv_ledger(pd.read_csv(path_raw_list)),
     )
     selected = filter_time_range(
         df=df_Sv,
@@ -551,7 +551,7 @@ def flow_create_MVBS_postprocessing(
         ledger_path=file_MVBS_csv,
         columns=MVBS_COLUMNS_POSTPROCESSING,
         date_columns=["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
-        builder=lambda: build_mvbs_ledger(df_Sv, slice_mins),
+        builder=lambda: build_MVBS_ledger(df_Sv, slice_mins),
     )
 
     # Get MVBS slices to be computed based on raw-to-Sv completions

--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -374,6 +374,9 @@ async def flow_create_MVBS(
 
     # Add MVBS slice info to dataframe
     for result in results:
+        if not result.has_data:
+            logger.info(f"No ping data found for {result.mvbs_filename}, skipping")
+            continue
         if result.mvbs_filename in df_MVBS["MVBS_filename"].values:
             logger.info(
                 f"MVBS file {result.mvbs_filename} already exists, "
@@ -585,6 +588,13 @@ def flow_create_MVBS_postprocessing(
         try:
             result = future.result()
             idx = df_MVBS.index[df_MVBS["slice_start"] == item.start_time][0]
+            if not result.has_data:
+                df_MVBS.loc[idx, ["MVBS_status", "error"]] = [
+                    "no_data",
+                    "No ping data in the planned slice",
+                ]
+                logger.info("No ping data found for MVBS slice %s", item.start_time)
+                continue
             df_MVBS.loc[
                 idx,
                 [

--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -33,9 +33,10 @@ from echodataflow.operations.operations_acoustics import (
     RawToSvWorkItem,
 )
 from echodataflow.operations.operations_postprocessing import (
-    read_or_create_mvbs_ledger,
-    read_or_create_sv_ledger,
+    build_mvbs_ledger,
+    build_sv_ledger,
     plan_mvbs_slices,
+    read_or_create_ledger,
 )
 from echodataflow.operations.operations_storage import S3CopySettings, S3CopyWorkItem
 from echodataflow.tasks.tasks_acoustics import (
@@ -430,7 +431,12 @@ def flow_raw2Sv_postprocessing(
     file_Sv_csv = Path(path_main) / file_Sv_csv
 
     # Initialize the complete ledger before selecting work for this run
-    df_Sv = read_or_create_sv_ledger(path_raw_list, file_Sv_csv)
+    df_Sv = read_or_create_ledger(
+        ledger_path=file_Sv_csv,
+        columns=SV_COLUMNS_POSTPROCESSING,
+        date_columns=["timestamp", "first_ping_time", "last_ping_time"],
+        builder=lambda: build_sv_ledger(pd.read_csv(path_raw_list)),
+    )
     selected = filter_time_range(
         df=df_Sv,
         column_start_time="timestamp",
@@ -538,7 +544,12 @@ def flow_create_MVBS_postprocessing(
         date_columns=["timestamp", "first_ping_time", "last_ping_time"],
     )
     # Preplan every MVBS row once from the complete raw-file timeline
-    df_MVBS = read_or_create_mvbs_ledger(file_MVBS_csv, df_Sv, slice_mins)
+    df_MVBS = read_or_create_ledger(
+        ledger_path=file_MVBS_csv,
+        columns=MVBS_COLUMNS_POSTPROCESSING,
+        date_columns=["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
+        builder=lambda: build_mvbs_ledger(df_Sv, slice_mins),
+    )
 
     # Get MVBS slices to be computed based on raw-to-Sv completions
     planned = plan_mvbs_slices(df_Sv, df_MVBS)

--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -23,6 +23,7 @@ from echodataflow.utils.manifests import (
     SV_COLUMNS_POSTPROCESSING,
     filter_slices,
     filter_time_range,
+    manifest_signature_changed,
     read_manifest,
     write_manifest,
 )
@@ -51,20 +52,18 @@ from echodataflow.utils.utils import (
 # otherwise all logging will be muted
 ep.utils.log.verbose()
 
-@flow(
-    log_prints=True,
-    task_runner=DaskTaskRunner()
-)
+
+@flow(log_prints=True, task_runner=DaskTaskRunner())
 def flow_raw2Sv(
-    exclude_before: str|None = None,
+    exclude_before: str | None = None,
     exclude_raw_file: list[str] = [],
     parallel: bool = False,
     encode_mode: str = "power",
     waveform_mode: str = "CW",
     depth_offset: float = 9.5,
     sonar_model: str = "EK80",
-    datagram_type: str|None = None,
-    nmea_sentence: str|None = None,
+    datagram_type: str | None = None,
+    nmea_sentence: str | None = None,
     filename_pattern: str = "*.raw",
     path_main: str = "",
     path_raw: str = "",
@@ -75,12 +74,14 @@ def flow_raw2Sv(
     # Check if the deployment is already running
     already_running = asyncio.run(deployment_already_running())
     if already_running:
+
         async def cancel_run():
             async with get_client() as client:
                 await client.set_flow_run_state(
                     flow_run_id=runtime.flow_run.id,
-                    state=Cancelled(message="Another instance of this flow is already running")
+                    state=Cancelled(message="Another instance of this flow is already running"),
                 )
+
         asyncio.run(cancel_run())
         return  # exit the flow early
 
@@ -104,20 +105,20 @@ def flow_raw2Sv(
     if not sv_manifest_exists:
         write_manifest(df_Sv, file_Sv_csv)
     if not df_Sv.empty:
-        df_Sv.sort_values(
-            by="first_ping_time",
-            inplace=True,
-            ignore_index=True
-        )
+        df_Sv.sort_values(by="first_ping_time", inplace=True, ignore_index=True)
 
     # Exclude raw files before exclude_before datetime
     if exclude_before is None:
         raw_files_in_folder = set([filename.name for filename in path_raw.glob(filename_pattern)])
     else:
-        raw_files_in_folder = set([
-            filename.name for filename in path_raw.glob(filename_pattern)
-            if extract_datetime_from_filename(filename.name) >= datetime.datetime.fromisoformat(exclude_before)
-        ])
+        raw_files_in_folder = set(
+            [
+                filename.name
+                for filename in path_raw.glob(filename_pattern)
+                if extract_datetime_from_filename(filename.name)
+                >= datetime.datetime.fromisoformat(exclude_before)
+            ]
+        )
 
     if df_Sv.empty:
         raw_files_in_df = set()
@@ -151,10 +152,7 @@ def flow_raw2Sv(
             f"Limiting to first {new_file_num_limit} files."
         )
         new_files = new_files[:new_file_num_limit]
-    print(
-        f"Files to process: \n"
-        + "".join([f"- {nf}\n" for nf in new_files])
-    )
+    print(f"Files to process: \n" + "".join([f"- {nf}\n" for nf in new_files]))
 
     settings = RawToSvSettings(
         output_directory=path_Sv_zarr,
@@ -173,9 +171,7 @@ def flow_raw2Sv(
         print("Processing raw files in parallel")
         future_all = []
         for nf in new_files:
-            new_processed_raw = task_raw2Sv.with_options(
-                task_run_name=nf, name=nf, retries=3
-            )
+            new_processed_raw = task_raw2Sv.with_options(task_run_name=nf, name=nf, retries=3)
             future = new_processed_raw.submit(
                 RawToSvWorkItem(raw_path=str(path_raw / nf)),
                 settings,
@@ -192,9 +188,7 @@ def flow_raw2Sv(
         for nf in new_files:
             try:
                 print(f"Converting {nf}")
-                task_result = task_raw2Sv.with_options(
-                    task_run_name=nf, name=nf, retries=3
-                )(
+                task_result = task_raw2Sv.with_options(task_run_name=nf, name=nf, retries=3)(
                     RawToSvWorkItem(raw_path=str(path_raw / nf)),
                     settings,
                 )
@@ -208,36 +202,36 @@ def flow_raw2Sv(
         df_new = pd.DataFrame(
             [
                 {
-                    "raw_filename": result.raw_filename,
-                    "Sv_filename": result.sv_filename,
+                    "raw_filename": result.filename_raw,
+                    "Sv_filename": result.filename_Sv,
                     "first_ping_time": result.first_ping_time,
                     "last_ping_time": result.last_ping_time,
                 }
                 for result in results
             ]
         )
-        
+
         # Concatenate with existing df_Sv and save
         df_Sv = pd.concat([df_Sv, df_new], ignore_index=True)
-        df_Sv.sort_values(
-            by=["first_ping_time"],
-            inplace=True,
-            ignore_index=True
-        )
+        df_Sv.sort_values(by=["first_ping_time"], inplace=True, ignore_index=True)
         write_manifest(df_Sv, file_Sv_csv)
         print(f"Added {len(new_files)} new entries to tracking CSV")
 
     # Set flow to Failed state if any errors occurred
     if len(errors) > 0:
-        error_msg = f"{len(errors)} errors during raw to Sv conversion out of {len(new_files)} files"
+        error_msg = (
+            f"{len(errors)} errors during raw to Sv conversion out of {len(new_files)} files"
+        )
+
         async def set_failed_state():
             async with get_client() as client:
                 await client.set_flow_run_state(
-                    flow_run_id=runtime.flow_run.id,
-                    state=Failed(message=error_msg)
+                    flow_run_id=runtime.flow_run.id, state=Failed(message=error_msg)
                 )
+
         asyncio.run(set_failed_state())
         raise Exception(error_msg)
+
 
 @flow(log_prints=True)
 async def flow_create_MVBS(
@@ -268,7 +262,9 @@ async def flow_create_MVBS(
     end_time = round_up_mins(
         datetime.datetime.now() - datetime.timedelta(seconds=time_offset_seconds),
         slice_mins=slice_mins,
-    ).astimezone(datetime.timezone.utc)  # convert to UTC
+    ).astimezone(
+        datetime.timezone.utc
+    )  # convert to UTC
 
     logger.info(
         "flow started with parameters:\n"
@@ -291,7 +287,9 @@ async def flow_create_MVBS(
     # Validate zarr store paths
     if not path_Sv_zarr.exists():
         # raise ValueError("Sv zarr store does not exist, check raw2Sv flow!")
-        logger.info("Sv zarr store does not exist, check raw2Sv flow! Creating empty folder for now.")
+        logger.info(
+            "Sv zarr store does not exist, check raw2Sv flow! Creating empty folder for now."
+        )
         path_Sv_zarr.mkdir(parents=True, exist_ok=True)
     if not path_MVBS_zarr.exists():
         path_MVBS_zarr.mkdir(parents=True, exist_ok=True)
@@ -337,9 +335,9 @@ async def flow_create_MVBS(
 
         # Get Sv files in the specified time range
         Sv_filenames = sorted(
-        df_Sv[
-                (pd.to_datetime(df_Sv["last_ping_time"]) >= start_time[snum]) &
-                (pd.to_datetime(df_Sv["first_ping_time"]) <= end_time[snum])
+            df_Sv[
+                (pd.to_datetime(df_Sv["last_ping_time"]) >= start_time[snum])
+                & (pd.to_datetime(df_Sv["first_ping_time"]) <= end_time[snum])
             ]["Sv_filename"].tolist()
         )
         logger.info(
@@ -379,13 +377,9 @@ async def flow_create_MVBS(
                 f"MVBS file {result.mvbs_filename} already exists, "
                 "updating first and last ping times"
             )
-            idx_to_add = df_MVBS.index[
-                df_MVBS["MVBS_filename"] == result.mvbs_filename
-            ]
+            idx_to_add = df_MVBS.index[df_MVBS["MVBS_filename"] == result.mvbs_filename]
         else:
-            logger.info(
-                f"Adding new MVBS file {result.mvbs_filename} to tracking dataframe"
-            )
+            logger.info(f"Adding new MVBS file {result.mvbs_filename} to tracking dataframe")
             idx_to_add = len(df_MVBS)
         df_MVBS.loc[idx_to_add] = [
             result.mvbs_filename,
@@ -401,8 +395,7 @@ async def flow_create_MVBS(
         error_msg = f"{len(errors)} errors during MVBS creation out of {num_slices} slices"
         async with get_client() as client:
             await client.set_flow_run_state(
-                flow_run_id=runtime.flow_run.id,
-                state=Failed(message=error_msg)
+                flow_run_id=runtime.flow_run.id, state=Failed(message=error_msg)
             )
         raise Exception(error_msg)
 
@@ -434,10 +427,10 @@ def flow_raw2Sv_postprocessing(
 
     logger = get_run_logger()
     # Keep temporary raw files separate from persistent Sv outputs
-    staging = Path(path_main) / "raw_staging"
-    sv_directory = Path(path_main) / "Sv"
-    staging.mkdir(parents=True, exist_ok=True)
-    sv_directory.mkdir(parents=True, exist_ok=True)
+    path_raw_staging = Path(path_main) / "raw_staging"
+    path_Sv = Path(path_main) / "Sv"
+    path_raw_staging.mkdir(parents=True, exist_ok=True)
+    path_Sv.mkdir(parents=True, exist_ok=True)
     raw_manifest_path = Path(path_main) / file_raw_processing_csv
     sv_manifest_path = Path(path_main) / file_Sv_csv
 
@@ -458,11 +451,11 @@ def flow_raw2Sv_postprocessing(
         raise ValueError("selected S3 paths contain duplicate basenames")
 
     # Resume from durable processing and output manifests
-    raw_manifest = read_manifest(raw_manifest_path, RAW_COLUMNS, ["timestamp"])
-    sv_manifest = read_manifest(
+    df_raw = read_manifest(raw_manifest_path, RAW_COLUMNS, ["timestamp"])
+    df_Sv = read_manifest(
         sv_manifest_path, SV_COLUMNS_POSTPROCESSING, ["first_ping_time", "last_ping_time"]
     )
-    completed = set(raw_manifest.loc[raw_manifest["status"] == "completed", "s3_path"])
+    completed = set(df_raw.loc[df_raw["status"] == "completed", "s3_path"])
     selected = source if overwrite else source[~source["s3_path"].isin(completed)]
     if new_file_num_limit != -1:
         selected = selected.head(new_file_num_limit)
@@ -480,16 +473,16 @@ def flow_raw2Sv_postprocessing(
             "status": "pending",
             "error": "",
         }
-        matches = raw_manifest.index[raw_manifest["s3_path"] == key]
+        matches = df_raw.index[df_raw["s3_path"] == key]
         if len(matches):
-            raw_manifest.loc[matches[0], RAW_COLUMNS] = list(values.values())
+            df_raw.loc[matches[0], RAW_COLUMNS] = list(values.values())
         else:
-            raw_manifest.loc[len(raw_manifest), RAW_COLUMNS] = list(values.values())
-    write_manifest(raw_manifest, raw_manifest_path)
+            df_raw.loc[len(df_raw), RAW_COLUMNS] = list(values.values())
+    write_manifest(df_raw, raw_manifest_path)
 
     copy_settings = S3CopySettings(s3_bucket=s3_bucket, endpoint_url=endpoint_url)
     sv_settings = RawToSvSettings(
-        output_directory=str(sv_directory),
+        output_directory=str(path_Sv),
         encode_mode=encode_mode,
         waveform_mode=waveform_mode,
         depth_offset=depth_offset,
@@ -509,7 +502,7 @@ def flow_raw2Sv_postprocessing(
             retries=task_retries,
             retry_delay_seconds=task_retry_delay_seconds,
         ).submit(
-            S3CopyWorkItem(s3_path=key, local_path=str(staging / filename)),
+            S3CopyWorkItem(s3_path=key, local_path=str(path_raw_staging / filename)),
             copy_settings,
             sv_settings,
         )
@@ -518,7 +511,7 @@ def flow_raw2Sv_postprocessing(
     # Persist each result immediately so polling MVBS runs can observe progress
     for future in as_completed(conversion_futures):
         key = conversion_futures[future]
-        idx = raw_manifest.index[raw_manifest["s3_path"] == key][0]
+        idx = df_raw.index[df_raw["s3_path"] == key][0]
         try:
             result = future.result()
             record = [
@@ -528,19 +521,19 @@ def flow_raw2Sv_postprocessing(
                 result.first_ping_time,
                 result.last_ping_time,
             ]
-            matches = sv_manifest.index[sv_manifest["s3_path"] == key]
+            matches = df_Sv.index[df_Sv["s3_path"] == key]
             if len(matches):
-                sv_manifest.loc[matches[0], SV_COLUMNS_POSTPROCESSING] = record
+                df_Sv.loc[matches[0], SV_COLUMNS_POSTPROCESSING] = record
             else:
-                sv_manifest.loc[len(sv_manifest), SV_COLUMNS_POSTPROCESSING] = record
-            raw_manifest.loc[idx, ["status", "error"]] = ["completed", ""]
-            write_manifest(sv_manifest, sv_manifest_path)
-            write_manifest(raw_manifest, raw_manifest_path)
+                df_Sv.loc[len(df_Sv), SV_COLUMNS_POSTPROCESSING] = record
+            df_raw.loc[idx, ["status", "error"]] = ["completed", ""]
+            write_manifest(df_Sv, sv_manifest_path)
+            write_manifest(df_raw, raw_manifest_path)
             logger.info("Completed %s", key)
         except Exception as exc:
             errors.append(exc)
-            raw_manifest.loc[idx, ["status", "error"]] = ["failed", str(exc)]
-            write_manifest(raw_manifest, raw_manifest_path)
+            df_raw.loc[idx, ["status", "error"]] = ["failed", str(exc)]
+            write_manifest(df_raw, raw_manifest_path)
             logger.error("Failed to download or convert %s: %s", key, exc)
     if errors:
         raise RuntimeError(f"{len(errors)} raw-to-Sv conversions failed")
@@ -564,33 +557,39 @@ def flow_create_MVBS_postprocessing(
         raise ValueError("overwrite=True requires explicit start_time and end_time")
 
     logger = get_run_logger()
-    root = Path(path_main)
-    mvbs_directory = root / "MVBS"
-    mvbs_directory.mkdir(parents=True, exist_ok=True)
+    path_MVBS = Path(path_main) / "MVBS"
+    path_MVBS.mkdir(parents=True, exist_ok=True)
     # Load input state and previously completed MVBS outputs
-    raw = read_manifest(root / file_raw_processing_csv, RAW_COLUMNS, ["timestamp"])
-    sv = read_manifest(root / file_Sv_csv, SV_COLUMNS_POSTPROCESSING, ["first_ping_time", "last_ping_time"])
-    manifest_path = root / file_MVBS_csv
-    manifest = read_manifest(
+    df_raw = read_manifest(Path(path_main) / file_raw_processing_csv, RAW_COLUMNS, ["timestamp"])
+    df_Sv = read_manifest(
+        Path(path_main) / file_Sv_csv, SV_COLUMNS_POSTPROCESSING, ["first_ping_time", "last_ping_time"]
+    )
+    manifest_path = Path(path_main) / file_MVBS_csv
+    df_MVBS = read_manifest(
         manifest_path,
         MVBS_COLUMNS_POSTPROCESSING,
-        ["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
+        ["first_ping_time", "last_ping_time"],
     )
-    # Plan only sealed slices, then discard outputs already present in the manifest
-    planned = filter_slices(plan_mvbs_slices(raw, sv, slice_mins), start_time, end_time)
-    existing = set(manifest["MVBS_filename"]) if not overwrite else set()
+    # Plan sealed slices and retain new outputs or outputs with changed inputs
+    planned = filter_slices(plan_mvbs_slices(df_raw, df_Sv, slice_mins), start_time, end_time)
     planned = [
         item
         for item in planned
-        if f"MVBS_{item.start_time:%Y%m%dT%H%M%S}.zarr" not in existing
+        if overwrite
+        or manifest_signature_changed(
+            df_MVBS,
+            "MVBS_filename",
+            f"MVBS_{item.start_time:%Y%m%dT%H%M%S}.zarr",
+            item.input_signature,
+        )
     ]
     if not planned:
         logger.info("No newly ready MVBS slices")
         return
 
     settings = CreateMVBSSettings(
-        sv_directory=str(root / "Sv"),
-        output_directory=str(mvbs_directory),
+        sv_directory=str(Path(path_main) / "Sv"),
+        output_directory=str(path_MVBS),
         range_bin=range_bin,
         ping_time_bin=ping_time_bin,
     )
@@ -617,20 +616,19 @@ def flow_create_MVBS_postprocessing(
             result = future.result()
             record = [
                 result.mvbs_filename,
-                item.start_time,
-                item.end_time,
                 result.first_ping_time,
                 result.last_ping_time,
                 item.is_partial,
+                item.input_signature,
             ]
-            matches = manifest.index[manifest["MVBS_filename"] == result.mvbs_filename]
+            matches = df_MVBS.index[df_MVBS["MVBS_filename"] == result.mvbs_filename]
             if len(matches):
-                manifest.loc[matches[0], MVBS_COLUMNS_POSTPROCESSING] = record
+                df_MVBS.loc[matches[0], MVBS_COLUMNS_POSTPROCESSING] = record
             else:
-                manifest.loc[len(manifest), MVBS_COLUMNS_POSTPROCESSING] = record
+                df_MVBS.loc[len(df_MVBS), MVBS_COLUMNS_POSTPROCESSING] = record
         except Exception as exc:
             errors.append(exc)
             logger.error("MVBS slice %s failed: %s", item.start_time, exc)
-    write_manifest(manifest.sort_values("slice_start"), manifest_path)
+    write_manifest(df_MVBS.sort_values("first_ping_time"), manifest_path)
     if errors:
         raise RuntimeError(f"{len(errors)} MVBS slices failed")

--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -16,11 +16,11 @@ from prefect import runtime
 
 from echodataflow.flows.flows_helper import deployment_already_running
 from echodataflow.utils.manifests import (
-    MVBS_COLUMNS,
+    MVBS_COLUMNS_POSTPROCESSING,
     RAW_COLUMNS,
-    REALTIME_MVBS_COLUMNS,
-    REALTIME_SV_COLUMNS,
-    SV_COLUMNS,
+    MVBS_COLUMNS_REALTIME,
+    SV_COLUMNS_REALTIME,
+    SV_COLUMNS_POSTPROCESSING,
     filter_slices,
     filter_time_range,
     read_manifest,
@@ -98,7 +98,7 @@ def flow_raw2Sv(
     sv_manifest_exists = file_Sv_csv.exists()
     df_Sv = read_manifest(
         file_Sv_csv,
-        REALTIME_SV_COLUMNS,
+        SV_COLUMNS_REALTIME,
         ["first_ping_time", "last_ping_time"],
     )
     if not sv_manifest_exists:
@@ -303,7 +303,7 @@ async def flow_create_MVBS(
         raise ValueError("Sv info csv does not exist, check raw2Sv flow!")
     df_Sv = read_manifest(
         file_Sv_csv,
-        REALTIME_SV_COLUMNS,
+        SV_COLUMNS_REALTIME,
         ["first_ping_time", "last_ping_time"],
     )
     if df_Sv.empty:
@@ -316,7 +316,7 @@ async def flow_create_MVBS(
     mvbs_manifest_exists = file_MVBS_csv.exists()
     df_MVBS = read_manifest(
         file_MVBS_csv,
-        REALTIME_MVBS_COLUMNS,
+        MVBS_COLUMNS_REALTIME,
         ["first_ping_time", "last_ping_time"],
     )
     if not mvbs_manifest_exists:
@@ -457,7 +457,7 @@ def flow_raw2Sv_postprocessing(
     # Resume from durable processing and output manifests
     raw_manifest = read_manifest(raw_manifest_path, RAW_COLUMNS, ["timestamp"])
     sv_manifest = read_manifest(
-        sv_manifest_path, SV_COLUMNS, ["first_ping_time", "last_ping_time"]
+        sv_manifest_path, SV_COLUMNS_POSTPROCESSING, ["first_ping_time", "last_ping_time"]
     )
     completed = set(raw_manifest.loc[raw_manifest["status"] == "completed", "s3_path"])
     selected = source if overwrite else source[~source["s3_path"].isin(completed)]
@@ -527,9 +527,9 @@ def flow_raw2Sv_postprocessing(
             ]
             matches = sv_manifest.index[sv_manifest["s3_path"] == key]
             if len(matches):
-                sv_manifest.loc[matches[0], SV_COLUMNS] = record
+                sv_manifest.loc[matches[0], SV_COLUMNS_POSTPROCESSING] = record
             else:
-                sv_manifest.loc[len(sv_manifest), SV_COLUMNS] = record
+                sv_manifest.loc[len(sv_manifest), SV_COLUMNS_POSTPROCESSING] = record
             raw_manifest.loc[idx, ["status", "error"]] = ["completed", ""]
             write_manifest(sv_manifest, sv_manifest_path)
             write_manifest(raw_manifest, raw_manifest_path)
@@ -563,11 +563,11 @@ def flow_create_MVBS_postprocessing(
     mvbs_directory.mkdir(parents=True, exist_ok=True)
     # Load input state and previously completed MVBS outputs
     raw = read_manifest(root / file_raw_processing_csv, RAW_COLUMNS, ["timestamp"])
-    sv = read_manifest(root / file_Sv_csv, SV_COLUMNS, ["first_ping_time", "last_ping_time"])
+    sv = read_manifest(root / file_Sv_csv, SV_COLUMNS_POSTPROCESSING, ["first_ping_time", "last_ping_time"])
     manifest_path = root / file_MVBS_csv
     manifest = read_manifest(
         manifest_path,
-        MVBS_COLUMNS,
+        MVBS_COLUMNS_POSTPROCESSING,
         ["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
     )
     # Plan only sealed slices, then discard outputs already present in the manifest
@@ -619,9 +619,9 @@ def flow_create_MVBS_postprocessing(
             ]
             matches = manifest.index[manifest["MVBS_filename"] == result.mvbs_filename]
             if len(matches):
-                manifest.loc[matches[0], MVBS_COLUMNS] = record
+                manifest.loc[matches[0], MVBS_COLUMNS_POSTPROCESSING] = record
             else:
-                manifest.loc[len(manifest), MVBS_COLUMNS] = record
+                manifest.loc[len(manifest), MVBS_COLUMNS_POSTPROCESSING] = record
         except Exception as exc:
             errors.append(exc)
             logger.error("MVBS slice %s failed: %s", item.start_time, exc)

--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -10,11 +10,11 @@ import echopype as ep
 
 from prefect import flow, get_run_logger, get_client
 from prefect.futures import as_completed
-from prefect_dask import DaskTaskRunner
 from prefect.states import Cancelled, Failed
 from prefect import runtime
 
 from echodataflow.flows.flows_helper import deployment_already_running
+from echodataflow.deployment.task_runners import dask_task_runner_from_environment
 from echodataflow.utils.manifests import (
     MVBS_COLUMNS_POSTPROCESSING,
     MVBS_COLUMNS_REALTIME,
@@ -55,7 +55,7 @@ from echodataflow.utils.utils import (
 ep.utils.log.verbose()
 
 
-@flow(log_prints=True, task_runner=DaskTaskRunner())
+@flow(log_prints=True, task_runner=dask_task_runner_from_environment())
 def flow_raw2Sv(
     exclude_before: str | None = None,
     exclude_raw_file: list[str] = [],
@@ -405,7 +405,7 @@ async def flow_create_MVBS(
         raise Exception(error_msg)
 
 
-@flow(log_prints=True, task_runner=DaskTaskRunner())
+@flow(log_prints=True, task_runner=dask_task_runner_from_environment())
 def flow_raw2Sv_postprocessing(
     path_raw_list: str,
     path_main: str,
@@ -521,7 +521,7 @@ def flow_raw2Sv_postprocessing(
         raise RuntimeError(f"{len(errors)} raw-to-Sv conversions failed")
 
 
-@flow(log_prints=True, task_runner=DaskTaskRunner())
+@flow(log_prints=True, task_runner=dask_task_runner_from_environment())
 def flow_create_MVBS_postprocessing(
     path_main: str,
     slice_mins: int = 20,

--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -429,6 +429,9 @@ def flow_raw2Sv_postprocessing(
     file_Sv_csv: str = "Sv_files.csv",
 ) -> None:
     """Stage selected S3 raw files and convert them concurrently to Sv."""
+    if overwrite and (start_time is None or end_time is None):
+        raise ValueError("overwrite=True requires explicit start_time and end_time")
+
     logger = get_run_logger()
     # Keep temporary raw files separate from persistent Sv outputs
     staging = Path(path_main) / "raw_staging"
@@ -557,6 +560,9 @@ def flow_create_MVBS_postprocessing(
     file_MVBS_csv: str = "MVBS_files.csv",
 ) -> None:
     """Create every newly ready MVBS slice registered by raw-to-Sv runs."""
+    if overwrite and (start_time is None or end_time is None):
+        raise ValueError("overwrite=True requires explicit start_time and end_time")
+
     logger = get_run_logger()
     root = Path(path_main)
     mvbs_directory = root / "MVBS"

--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -18,6 +18,8 @@ from echodataflow.flows.flows_helper import deployment_already_running
 from echodataflow.utils.manifests import (
     MVBS_COLUMNS,
     RAW_COLUMNS,
+    REALTIME_MVBS_COLUMNS,
+    REALTIME_SV_COLUMNS,
     SV_COLUMNS,
     filter_slices,
     filter_time_range,
@@ -48,7 +50,6 @@ from echodataflow.utils.utils import (
 # Turn on verbose logging for echopype
 # otherwise all logging will be muted
 ep.utils.log.verbose()
-
 
 @flow(
     log_prints=True,
@@ -94,18 +95,15 @@ def flow_raw2Sv(
     path_Sv_zarr = str(path_Sv_zarr)  # convert backto string to pass into task
 
     # Load info dataframe containing raw to Sv correspondence
-    if not file_Sv_csv.exists():
-        df_Sv = pd.DataFrame(
-            columns=["raw_filename", "Sv_filename", "first_ping_time", "last_ping_time"]
-        )
-        df_Sv.to_csv(file_Sv_csv)
-    else:
-        df_Sv = pd.read_csv(
-            file_Sv_csv,
-            index_col=0,
-            date_format="ISO8601",
-            parse_dates=["first_ping_time", "last_ping_time"]
-        )
+    sv_manifest_exists = file_Sv_csv.exists()
+    df_Sv = read_manifest(
+        file_Sv_csv,
+        REALTIME_SV_COLUMNS,
+        ["first_ping_time", "last_ping_time"],
+    )
+    if not sv_manifest_exists:
+        write_manifest(df_Sv, file_Sv_csv)
+    if not df_Sv.empty:
         df_Sv.sort_values(
             by="first_ping_time",
             inplace=True,
@@ -226,7 +224,7 @@ def flow_raw2Sv(
             inplace=True,
             ignore_index=True
         )
-        df_Sv.to_csv(file_Sv_csv, date_format="%Y-%m-%dT%H:%M:%S.%f")
+        write_manifest(df_Sv, file_Sv_csv)
         print(f"Added {len(new_files)} new entries to tracking CSV")
 
     # Set flow to Failed state if any errors occurred
@@ -303,37 +301,26 @@ async def flow_create_MVBS(
     # Load Sv and MVBS info dataframes
     if not file_Sv_csv.exists():
         raise ValueError("Sv info csv does not exist, check raw2Sv flow!")
-    df_Sv = pd.read_csv(
+    df_Sv = read_manifest(
         file_Sv_csv,
-        index_col=0,
-        date_format="ISO8601",
-        parse_dates=["first_ping_time", "last_ping_time"]
+        REALTIME_SV_COLUMNS,
+        ["first_ping_time", "last_ping_time"],
     )
-    # Convert last_ping_time and first_ping_time to UTC
-    if not df_Sv.empty:
-        if df_Sv["last_ping_time"].dt.tz is None:
-            df_Sv["last_ping_time"] = df_Sv["last_ping_time"].dt.tz_localize("UTC")
-        if df_Sv["first_ping_time"].dt.tz is None:
-            df_Sv["first_ping_time"] = df_Sv["first_ping_time"].dt.tz_localize("UTC")
-    else:
+    if df_Sv.empty:
         logger.info(
             "Sv info csv is empty, raw2Sv flow may have just started! "
             "No MVBS can be created, exiting flow."
         )
         return
 
-    if not file_MVBS_csv.exists():
-        df_MVBS = pd.DataFrame(
-            columns=["MVBS_filename", "first_ping_time", "last_ping_time"]
-        )
-        df_MVBS.to_csv(file_MVBS_csv)
-    else:
-        df_MVBS = pd.read_csv(
-            file_MVBS_csv,
-            index_col=0,
-            date_format="ISO8601",
-            parse_dates=["first_ping_time", "last_ping_time"]
-        )
+    mvbs_manifest_exists = file_MVBS_csv.exists()
+    df_MVBS = read_manifest(
+        file_MVBS_csv,
+        REALTIME_MVBS_COLUMNS,
+        ["first_ping_time", "last_ping_time"],
+    )
+    if not mvbs_manifest_exists:
+        write_manifest(df_MVBS, file_MVBS_csv)
 
     settings = CreateMVBSSettings(
         sv_directory=path_Sv_zarr,
@@ -407,7 +394,7 @@ async def flow_create_MVBS(
         ]
 
     # Save updated MVBS info dataframe
-    df_MVBS.to_csv(file_MVBS_csv, date_format="%Y-%m-%dT%H:%M:%S")
+    write_manifest(df_MVBS, file_MVBS_csv)
 
     # Set flow to Failed state if any errors occurred
     if len(errors) > 0:

--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -17,13 +17,11 @@ from prefect import runtime
 from echodataflow.flows.flows_helper import deployment_already_running
 from echodataflow.utils.manifests import (
     MVBS_COLUMNS_POSTPROCESSING,
-    RAW_COLUMNS,
     MVBS_COLUMNS_REALTIME,
     SV_COLUMNS_REALTIME,
     SV_COLUMNS_POSTPROCESSING,
     filter_slices,
     filter_time_range,
-    manifest_signature_changed,
     read_manifest,
     write_manifest,
 )
@@ -35,7 +33,11 @@ from echodataflow.operations.operations_acoustics import (
     RawToSvSettings,
     RawToSvWorkItem,
 )
-from echodataflow.operations.operations_postprocessing import plan_mvbs_slices
+from echodataflow.operations.operations_postprocessing import (
+    read_or_create_mvbs_ledger,
+    read_or_create_sv_ledger,
+    plan_mvbs_slices,
+)
 from echodataflow.operations.operations_storage import S3CopySettings, S3CopyWorkItem
 from echodataflow.tasks.tasks_acoustics import (
     task_create_MVBS,
@@ -409,7 +411,6 @@ def flow_raw2Sv_postprocessing(
     start_time: str | None = None,
     end_time: str | None = None,
     new_file_num_limit: int = -1,
-    overwrite: bool = False,
     task_retries: int = 3,
     task_retry_delay_seconds: int = 30,
     encode_mode: str = "power",
@@ -418,67 +419,36 @@ def flow_raw2Sv_postprocessing(
     sonar_model: str = "EK80",
     datagram_type: str | None = None,
     nmea_sentence: str | None = None,
-    file_raw_processing_csv: str = "raw_processing.csv",
     file_Sv_csv: str = "Sv_files.csv",
 ) -> None:
-    """Stage selected S3 raw files and convert them concurrently to Sv."""
-    if overwrite and (start_time is None or end_time is None):
-        raise ValueError("overwrite=True requires explicit start_time and end_time")
-
+    """Convert raw files and update corresponding rows in the Sv ledger."""
     logger = get_run_logger()
     # Keep temporary raw files separate from persistent Sv outputs
     path_raw_staging = Path(path_main) / "raw_staging"
     path_Sv = Path(path_main) / "Sv"
     path_raw_staging.mkdir(parents=True, exist_ok=True)
     path_Sv.mkdir(parents=True, exist_ok=True)
-    raw_manifest_path = Path(path_main) / file_raw_processing_csv
-    sv_manifest_path = Path(path_main) / file_Sv_csv
+    file_Sv_csv = Path(path_main) / file_Sv_csv
 
-    # Select the requested portion of the reusable S3 source manifest
-    source = pd.read_csv(path_raw_list)
-    required = {"s3_path", "timestamp"}
-    if not required.issubset(source.columns):
-        raise ValueError(f"raw list must contain columns: {sorted(required)}")
-    source["timestamp"] = pd.to_datetime(source["timestamp"], utc=True)
-    source = filter_time_range(
-        source,
-        "timestamp",
-        start_time,
-        end_time,
-        include_boundary_neighbors=True,
+    # Initialize the complete ledger before selecting work for this run
+    df_Sv = read_or_create_sv_ledger(path_raw_list, file_Sv_csv)
+    selected = filter_time_range(
+        df=df_Sv,
+        column_start_time="timestamp",
+        column_end_time=None,
+        start_time=start_time,
+        end_time=end_time,
     )
-    if source["s3_path"].map(lambda value: Path(str(value)).name).duplicated().any():
-        raise ValueError("selected S3 paths contain duplicate basenames")
-
-    # Resume from durable processing and output manifests
-    df_raw = read_manifest(raw_manifest_path, RAW_COLUMNS, ["timestamp"])
-    df_Sv = read_manifest(
-        sv_manifest_path, SV_COLUMNS_POSTPROCESSING, ["first_ping_time", "last_ping_time"]
-    )
-    completed = set(df_raw.loc[df_raw["status"] == "completed", "s3_path"])
-    selected = source if overwrite else source[~source["s3_path"].isin(completed)]
+    selected = selected[selected["raw2Sv_status"] != "completed"]
     if new_file_num_limit != -1:
         selected = selected.head(new_file_num_limit)
     if selected.empty:
         logger.info("No raw files require processing")
         return
 
-    # Register all selected inputs before workers begin completing out of order
-    for row in selected.itertuples(index=False):
-        key = str(row.s3_path)
-        values = {
-            "s3_path": key,
-            "timestamp": row.timestamp,
-            "raw_filename": Path(key).name,
-            "status": "pending",
-            "error": "",
-        }
-        matches = df_raw.index[df_raw["s3_path"] == key]
-        if len(matches):
-            df_raw.loc[matches[0], RAW_COLUMNS] = list(values.values())
-        else:
-            df_raw.loc[len(df_raw), RAW_COLUMNS] = list(values.values())
-    write_manifest(df_raw, raw_manifest_path)
+    # Mark submitted work before workers begin completing out of order
+    df_Sv.loc[selected.index, ["raw2Sv_status", "error"]] = ["pending", ""]
+    write_manifest(df_Sv, file_Sv_csv)
 
     copy_settings = S3CopySettings(s3_bucket=s3_bucket, endpoint_url=endpoint_url)
     sv_settings = RawToSvSettings(
@@ -511,29 +481,33 @@ def flow_raw2Sv_postprocessing(
     # Persist each result immediately so polling MVBS runs can observe progress
     for future in as_completed(conversion_futures):
         key = conversion_futures[future]
-        idx = df_raw.index[df_raw["s3_path"] == key][0]
+        idx = df_Sv.index[df_Sv["s3_path"] == key][0]
         try:
             result = future.result()
-            record = [
-                key,
-                result.raw_filename,
-                result.sv_filename,
+            df_Sv.loc[
+                idx,
+                [
+                    "raw_filename",
+                    "Sv_filename",
+                    "raw2Sv_status",
+                    "first_ping_time",
+                    "last_ping_time",
+                    "error",
+                ],
+            ] = [
+                result.filename_raw,
+                result.filename_Sv,
+                "completed",
                 result.first_ping_time,
                 result.last_ping_time,
+                "",
             ]
-            matches = df_Sv.index[df_Sv["s3_path"] == key]
-            if len(matches):
-                df_Sv.loc[matches[0], SV_COLUMNS_POSTPROCESSING] = record
-            else:
-                df_Sv.loc[len(df_Sv), SV_COLUMNS_POSTPROCESSING] = record
-            df_raw.loc[idx, ["status", "error"]] = ["completed", ""]
-            write_manifest(df_Sv, sv_manifest_path)
-            write_manifest(df_raw, raw_manifest_path)
+            write_manifest(df_Sv, file_Sv_csv)
             logger.info("Completed %s", key)
         except Exception as exc:
             errors.append(exc)
-            df_raw.loc[idx, ["status", "error"]] = ["failed", str(exc)]
-            write_manifest(df_raw, raw_manifest_path)
+            df_Sv.loc[idx, ["raw2Sv_status", "error"]] = ["failed", str(exc)]
+            write_manifest(df_Sv, file_Sv_csv)
             logger.error("Failed to download or convert %s: %s", key, exc)
     if errors:
         raise RuntimeError(f"{len(errors)} raw-to-Sv conversions failed")
@@ -545,43 +519,39 @@ def flow_create_MVBS_postprocessing(
     slice_mins: int = 20,
     start_time: str | None = None,
     end_time: str | None = None,
-    overwrite: bool = False,
     range_bin: str = "1m",
     ping_time_bin: str = "5s",
-    file_raw_processing_csv: str = "raw_processing.csv",
     file_Sv_csv: str = "Sv_files.csv",
     file_MVBS_csv: str = "MVBS_files.csv",
 ) -> None:
-    """Create every newly ready MVBS slice registered by raw-to-Sv runs."""
-    if overwrite and (start_time is None or end_time is None):
-        raise ValueError("overwrite=True requires explicit start_time and end_time")
-
+    """Create preplanned MVBS slices after all required raw conversions finish."""
     logger = get_run_logger()
+    file_Sv_csv = Path(path_main) / file_Sv_csv
+    if not file_Sv_csv.exists():
+        logger.info("Sv ledger does not yet exist")
+        return
+
     path_MVBS = Path(path_main) / "MVBS"
     path_MVBS.mkdir(parents=True, exist_ok=True)
-    # Load input state and previously completed MVBS outputs
-    df_raw = read_manifest(Path(path_main) / file_raw_processing_csv, RAW_COLUMNS, ["timestamp"])
+    file_MVBS_csv = Path(path_main) / file_MVBS_csv
+    # Raw-to-Sv owns Sv ledger initialization
     df_Sv = read_manifest(
-        Path(path_main) / file_Sv_csv, SV_COLUMNS_POSTPROCESSING, ["first_ping_time", "last_ping_time"]
+        path=file_Sv_csv,
+        columns=SV_COLUMNS_POSTPROCESSING,
+        date_columns=["timestamp", "first_ping_time", "last_ping_time"],
     )
-    manifest_path = Path(path_main) / file_MVBS_csv
-    df_MVBS = read_manifest(
-        manifest_path,
-        MVBS_COLUMNS_POSTPROCESSING,
-        ["first_ping_time", "last_ping_time"],
-    )
-    # Plan sealed slices and retain new outputs or outputs with changed inputs
-    planned = filter_slices(plan_mvbs_slices(df_raw, df_Sv, slice_mins), start_time, end_time)
+    # Preplan every MVBS row once from the complete raw-file timeline
+    df_MVBS = read_or_create_mvbs_ledger(file_MVBS_csv, df_Sv, slice_mins)
+
+    planned = filter_slices(plan_mvbs_slices(df_Sv, df_MVBS), start_time, end_time)
     planned = [
         item
         for item in planned
-        if overwrite
-        or manifest_signature_changed(
-            df_MVBS,
-            "MVBS_filename",
-            f"MVBS_{item.start_time:%Y%m%dT%H%M%S}.zarr",
-            item.input_signature,
-        )
+        if df_MVBS.loc[
+            df_MVBS["slice_start"] == item.start_time,
+            "MVBS_status",
+        ].iloc[0]
+        != "completed"
     ]
     if not planned:
         logger.info("No newly ready MVBS slices")
@@ -616,10 +586,17 @@ def flow_create_MVBS_postprocessing(
             result = future.result()
             record = [
                 result.mvbs_filename,
+                item.start_time,
+                item.end_time,
+                df_MVBS.loc[
+                    df_MVBS["slice_start"] == item.start_time,
+                    "raw_filenames",
+                ].iloc[0],
                 result.first_ping_time,
                 result.last_ping_time,
                 item.is_partial,
-                item.input_signature,
+                "completed",
+                "",
             ]
             matches = df_MVBS.index[df_MVBS["MVBS_filename"] == result.mvbs_filename]
             if len(matches):
@@ -628,7 +605,10 @@ def flow_create_MVBS_postprocessing(
                 df_MVBS.loc[len(df_MVBS), MVBS_COLUMNS_POSTPROCESSING] = record
         except Exception as exc:
             errors.append(exc)
+            filename = f"MVBS_{item.start_time:%Y%m%dT%H%M%S}.zarr"
+            idx = df_MVBS.index[df_MVBS["MVBS_filename"] == filename][0]
+            df_MVBS.loc[idx, ["MVBS_status", "error"]] = ["failed", str(exc)]
             logger.error("MVBS slice %s failed: %s", item.start_time, exc)
-    write_manifest(df_MVBS.sort_values("first_ping_time"), manifest_path)
+    write_manifest(df_MVBS.sort_values("slice_start"), file_MVBS_csv)
     if errors:
         raise RuntimeError(f"{len(errors)} MVBS slices failed")

--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -20,7 +20,6 @@ from echodataflow.utils.manifests import (
     MVBS_COLUMNS_REALTIME,
     SV_COLUMNS_REALTIME,
     SV_COLUMNS_POSTPROCESSING,
-    filter_slices,
     filter_time_range,
     read_manifest,
     write_manifest,
@@ -517,8 +516,6 @@ def flow_raw2Sv_postprocessing(
 def flow_create_MVBS_postprocessing(
     path_main: str,
     slice_mins: int = 20,
-    start_time: str | None = None,
-    end_time: str | None = None,
     range_bin: str = "1m",
     ping_time_bin: str = "5s",
     file_Sv_csv: str = "Sv_files.csv",
@@ -543,16 +540,8 @@ def flow_create_MVBS_postprocessing(
     # Preplan every MVBS row once from the complete raw-file timeline
     df_MVBS = read_or_create_mvbs_ledger(file_MVBS_csv, df_Sv, slice_mins)
 
-    planned = filter_slices(plan_mvbs_slices(df_Sv, df_MVBS), start_time, end_time)
-    planned = [
-        item
-        for item in planned
-        if df_MVBS.loc[
-            df_MVBS["slice_start"] == item.start_time,
-            "MVBS_status",
-        ].iloc[0]
-        != "completed"
-    ]
+    # Get MVBS slices to be computed based on raw-to-Sv completions
+    planned = plan_mvbs_slices(df_Sv, df_MVBS)
     if not planned:
         logger.info("No newly ready MVBS slices")
         return
@@ -584,25 +573,25 @@ def flow_create_MVBS_postprocessing(
         item = futures[future]
         try:
             result = future.result()
-            record = [
+            idx = df_MVBS.index[df_MVBS["slice_start"] == item.start_time][0]
+            df_MVBS.loc[
+                idx,
+                [
+                    "MVBS_filename",
+                    "first_ping_time",
+                    "last_ping_time",
+                    "is_partial",
+                    "MVBS_status",
+                    "error",
+                ],
+            ] = [
                 result.mvbs_filename,
-                item.start_time,
-                item.end_time,
-                df_MVBS.loc[
-                    df_MVBS["slice_start"] == item.start_time,
-                    "raw_filenames",
-                ].iloc[0],
                 result.first_ping_time,
                 result.last_ping_time,
                 item.is_partial,
                 "completed",
                 "",
             ]
-            matches = df_MVBS.index[df_MVBS["MVBS_filename"] == result.mvbs_filename]
-            if len(matches):
-                df_MVBS.loc[matches[0], MVBS_COLUMNS_POSTPROCESSING] = record
-            else:
-                df_MVBS.loc[len(df_MVBS), MVBS_COLUMNS_POSTPROCESSING] = record
         except Exception as exc:
             errors.append(exc)
             filename = f"MVBS_{item.start_time:%Y%m%dT%H%M%S}.zarr"

--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -9,11 +9,21 @@ import pandas as pd
 import echopype as ep
 
 from prefect import flow, get_run_logger, get_client
+from prefect.futures import as_completed
 from prefect_dask import DaskTaskRunner
 from prefect.states import Cancelled, Failed
 from prefect import runtime
 
 from echodataflow.flows.flows_helper import deployment_already_running
+from echodataflow.utils.manifests import (
+    MVBS_COLUMNS,
+    RAW_COLUMNS,
+    SV_COLUMNS,
+    filter_slices,
+    filter_time_range,
+    read_manifest,
+    write_manifest,
+)
 from echodataflow.operations.operations_acoustics import (
     CreateMVBSResult,
     CreateMVBSSettings,
@@ -22,10 +32,13 @@ from echodataflow.operations.operations_acoustics import (
     RawToSvSettings,
     RawToSvWorkItem,
 )
+from echodataflow.operations.operations_postprocessing import plan_mvbs_slices
+from echodataflow.operations.operations_storage import S3CopySettings, S3CopyWorkItem
 from echodataflow.tasks.tasks_acoustics import (
     task_create_MVBS,
     task_raw2Sv,
 )
+from echodataflow.tasks.tasks_postprocessing import task_s3_raw2Sv
 from echodataflow.utils.utils import (
     round_up_mins,
     get_slice_start_end_times,
@@ -405,3 +418,226 @@ async def flow_create_MVBS(
                 state=Failed(message=error_msg)
             )
         raise Exception(error_msg)
+
+
+@flow(log_prints=True, task_runner=DaskTaskRunner())
+def flow_raw2Sv_postprocessing(
+    path_raw_list: str,
+    path_main: str,
+    s3_bucket: str = "noaa-wcsd-pds",
+    endpoint_url: str | None = "https://sdsc.osn.xsede.org",
+    start_time: str | None = None,
+    end_time: str | None = None,
+    new_file_num_limit: int = -1,
+    overwrite: bool = False,
+    task_retries: int = 3,
+    task_retry_delay_seconds: int = 30,
+    encode_mode: str = "power",
+    waveform_mode: str = "CW",
+    depth_offset: float = 9.5,
+    sonar_model: str = "EK80",
+    datagram_type: str | None = None,
+    nmea_sentence: str | None = None,
+    file_raw_processing_csv: str = "raw_processing.csv",
+    file_Sv_csv: str = "Sv_files.csv",
+) -> None:
+    """Stage selected S3 raw files and convert them concurrently to Sv."""
+    logger = get_run_logger()
+    # Keep temporary raw files separate from persistent Sv outputs
+    staging = Path(path_main) / "raw_staging"
+    sv_directory = Path(path_main) / "Sv"
+    staging.mkdir(parents=True, exist_ok=True)
+    sv_directory.mkdir(parents=True, exist_ok=True)
+    raw_manifest_path = Path(path_main) / file_raw_processing_csv
+    sv_manifest_path = Path(path_main) / file_Sv_csv
+
+    # Select the requested portion of the reusable S3 source manifest
+    source = pd.read_csv(path_raw_list)
+    required = {"s3_path", "timestamp"}
+    if not required.issubset(source.columns):
+        raise ValueError(f"raw list must contain columns: {sorted(required)}")
+    source["timestamp"] = pd.to_datetime(source["timestamp"], utc=True)
+    source = filter_time_range(
+        source,
+        "timestamp",
+        start_time,
+        end_time,
+        include_boundary_neighbors=True,
+    )
+    if source["s3_path"].map(lambda value: Path(str(value)).name).duplicated().any():
+        raise ValueError("selected S3 paths contain duplicate basenames")
+
+    # Resume from durable processing and output manifests
+    raw_manifest = read_manifest(raw_manifest_path, RAW_COLUMNS, ["timestamp"])
+    sv_manifest = read_manifest(
+        sv_manifest_path, SV_COLUMNS, ["first_ping_time", "last_ping_time"]
+    )
+    completed = set(raw_manifest.loc[raw_manifest["status"] == "completed", "s3_path"])
+    selected = source if overwrite else source[~source["s3_path"].isin(completed)]
+    if new_file_num_limit != -1:
+        selected = selected.head(new_file_num_limit)
+    if selected.empty:
+        logger.info("No raw files require processing")
+        return
+
+    # Register all selected inputs before workers begin completing out of order
+    for row in selected.itertuples(index=False):
+        key = str(row.s3_path)
+        values = {
+            "s3_path": key,
+            "timestamp": row.timestamp,
+            "raw_filename": Path(key).name,
+            "status": "pending",
+            "error": "",
+        }
+        matches = raw_manifest.index[raw_manifest["s3_path"] == key]
+        if len(matches):
+            raw_manifest.loc[matches[0], RAW_COLUMNS] = list(values.values())
+        else:
+            raw_manifest.loc[len(raw_manifest), RAW_COLUMNS] = list(values.values())
+    write_manifest(raw_manifest, raw_manifest_path)
+
+    copy_settings = S3CopySettings(s3_bucket=s3_bucket, endpoint_url=endpoint_url)
+    sv_settings = RawToSvSettings(
+        output_directory=str(sv_directory),
+        encode_mode=encode_mode,
+        waveform_mode=waveform_mode,
+        depth_offset=depth_offset,
+        sonar_model=sonar_model,
+        datagram_type=datagram_type,
+        nmea_sentence=nmea_sentence,
+    )
+
+    # Submit one download-plus-conversion task per raw object
+    errors = []
+    conversion_futures = {}
+    for row in selected.itertuples(index=False):
+        key = str(row.s3_path)
+        filename = Path(key).name
+        future = task_s3_raw2Sv.with_options(
+            task_run_name=f"raw2Sv_{filename}",
+            retries=task_retries,
+            retry_delay_seconds=task_retry_delay_seconds,
+        ).submit(
+            S3CopyWorkItem(s3_path=key, local_path=str(staging / filename)),
+            copy_settings,
+            sv_settings,
+        )
+        conversion_futures[future] = key
+
+    # Persist each result immediately so polling MVBS runs can observe progress
+    for future in as_completed(conversion_futures):
+        key = conversion_futures[future]
+        idx = raw_manifest.index[raw_manifest["s3_path"] == key][0]
+        try:
+            result = future.result()
+            record = [
+                key,
+                result.raw_filename,
+                result.sv_filename,
+                result.first_ping_time,
+                result.last_ping_time,
+            ]
+            matches = sv_manifest.index[sv_manifest["s3_path"] == key]
+            if len(matches):
+                sv_manifest.loc[matches[0], SV_COLUMNS] = record
+            else:
+                sv_manifest.loc[len(sv_manifest), SV_COLUMNS] = record
+            raw_manifest.loc[idx, ["status", "error"]] = ["completed", ""]
+            write_manifest(sv_manifest, sv_manifest_path)
+            write_manifest(raw_manifest, raw_manifest_path)
+            logger.info("Completed %s", key)
+        except Exception as exc:
+            errors.append(exc)
+            raw_manifest.loc[idx, ["status", "error"]] = ["failed", str(exc)]
+            write_manifest(raw_manifest, raw_manifest_path)
+            logger.error("Failed to download or convert %s: %s", key, exc)
+    if errors:
+        raise RuntimeError(f"{len(errors)} raw-to-Sv conversions failed")
+
+
+@flow(log_prints=True, task_runner=DaskTaskRunner())
+def flow_create_MVBS_postprocessing(
+    path_main: str,
+    slice_mins: int = 20,
+    start_time: str | None = None,
+    end_time: str | None = None,
+    overwrite: bool = False,
+    range_bin: str = "1m",
+    ping_time_bin: str = "5s",
+    file_raw_processing_csv: str = "raw_processing.csv",
+    file_Sv_csv: str = "Sv_files.csv",
+    file_MVBS_csv: str = "MVBS_files.csv",
+) -> None:
+    """Create every newly ready MVBS slice registered by raw-to-Sv runs."""
+    logger = get_run_logger()
+    root = Path(path_main)
+    mvbs_directory = root / "MVBS"
+    mvbs_directory.mkdir(parents=True, exist_ok=True)
+    # Load input state and previously completed MVBS outputs
+    raw = read_manifest(root / file_raw_processing_csv, RAW_COLUMNS, ["timestamp"])
+    sv = read_manifest(root / file_Sv_csv, SV_COLUMNS, ["first_ping_time", "last_ping_time"])
+    manifest_path = root / file_MVBS_csv
+    manifest = read_manifest(
+        manifest_path,
+        MVBS_COLUMNS,
+        ["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
+    )
+    # Plan only sealed slices, then discard outputs already present in the manifest
+    planned = filter_slices(plan_mvbs_slices(raw, sv, slice_mins), start_time, end_time)
+    existing = set(manifest["MVBS_filename"]) if not overwrite else set()
+    planned = [
+        item
+        for item in planned
+        if f"MVBS_{item.start_time:%Y%m%dT%H%M%S}.zarr" not in existing
+    ]
+    if not planned:
+        logger.info("No newly ready MVBS slices")
+        return
+
+    settings = CreateMVBSSettings(
+        sv_directory=str(root / "Sv"),
+        output_directory=str(mvbs_directory),
+        range_bin=range_bin,
+        ping_time_bin=ping_time_bin,
+    )
+    # Ready slices are independent and can be computed in parallel
+    futures = {}
+    for item in planned:
+        filename = f"MVBS_{item.start_time:%Y%m%dT%H%M%S}.zarr"
+        future = task_create_MVBS.with_options(task_run_name=filename).submit(
+            CreateMVBSWorkItem(
+                start_time=item.start_time,
+                end_time=item.end_time,
+                sv_filenames=item.filenames,
+                mvbs_filename=filename,
+            ),
+            settings,
+        )
+        futures[future] = item
+
+    # Collect task results in memory so this flow remains the sole manifest writer
+    errors = []
+    for future in as_completed(futures):
+        item = futures[future]
+        try:
+            result = future.result()
+            record = [
+                result.mvbs_filename,
+                item.start_time,
+                item.end_time,
+                result.first_ping_time,
+                result.last_ping_time,
+                item.is_partial,
+            ]
+            matches = manifest.index[manifest["MVBS_filename"] == result.mvbs_filename]
+            if len(matches):
+                manifest.loc[matches[0], MVBS_COLUMNS] = record
+            else:
+                manifest.loc[len(manifest), MVBS_COLUMNS] = record
+        except Exception as exc:
+            errors.append(exc)
+            logger.error("MVBS slice %s failed: %s", item.start_time, exc)
+    write_manifest(manifest.sort_values("slice_start"), manifest_path)
+    if errors:
+        raise RuntimeError(f"{len(errors)} MVBS slices failed")

--- a/src/echodataflow/flows/flows_predict_hake.py
+++ b/src/echodataflow/flows/flows_predict_hake.py
@@ -250,7 +250,6 @@ async def flow_predict_hake(
 def flow_predict_hake_postprocessing(
     path_main: str,
     path_weight: str,
-    mvbs_slice_mins: int = 20,
     prediction_slice_mins: int = 40,
     temperature: float = 0.5,
     softmax_threshold: float = 0.5,
@@ -280,7 +279,6 @@ def flow_predict_hake_postprocessing(
         date_columns=["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
         builder=lambda: build_prediction_ledger(
             df_MVBS,
-            mvbs_slice_mins,
             prediction_slice_mins,
         ),
     )

--- a/src/echodataflow/flows/flows_predict_hake.py
+++ b/src/echodataflow/flows/flows_predict_hake.py
@@ -15,7 +15,6 @@ from echodataflow.utils.manifests import (
     PREDICTION_COLUMNS_POSTPROCESSING,
     MVBS_COLUMNS_REALTIME,
     PREDICTION_COLUMNS_REALTIME,
-    filter_slices,
     read_manifest,
     write_manifest,
 )
@@ -283,15 +282,13 @@ def flow_predict_hake_postprocessing(
         ["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
     )
     # Assemble aligned prediction windows from completed MVBS slices
-    planned = filter_slices(
-        plan_prediction_slices(
-            mvbs,
-            mvbs_slice_mins=mvbs_slice_mins,
-            prediction_slice_mins=prediction_slice_mins,
-            require_complete_window=require_complete_window,
-        ),
-        start_time,
-        end_time,
+    planned = plan_prediction_slices(
+        mvbs,
+        mvbs_slice_mins=mvbs_slice_mins,
+        prediction_slice_mins=prediction_slice_mins,
+        require_complete_window=require_complete_window,
+        start_time=start_time,
+        end_time=end_time,
     )
     completed = set(manifest["prediction_filename_postfix"].astype(str))
     planned = [

--- a/src/echodataflow/flows/flows_predict_hake.py
+++ b/src/echodataflow/flows/flows_predict_hake.py
@@ -261,6 +261,9 @@ def flow_predict_hake_postprocessing(
     file_prediction_csv: str = "prediction_files.csv",
 ) -> None:
     """Predict all newly ready windows, combining aligned MVBS slices."""
+    if overwrite and (start_time is None or end_time is None):
+        raise ValueError("overwrite=True requires explicit start_time and end_time")
+
     logger = get_run_logger()
     # Create persistent destinations before loading the model
     for directory in ["prediction", "EVR", "NASC"]:

--- a/src/echodataflow/flows/flows_predict_hake.py
+++ b/src/echodataflow/flows/flows_predict_hake.py
@@ -18,7 +18,11 @@ from echodataflow.utils.manifests import (
     read_manifest,
     write_manifest,
 )
-from echodataflow.operations.operations_postprocessing import plan_prediction_slices
+from echodataflow.operations.operations_postprocessing import (
+    build_prediction_ledger,
+    plan_prediction_slices,
+    read_or_create_ledger,
+)
 from echodataflow.operations.operations_predict_hake import (
     ComputeNASCSettings,
     ComputeNASCWorkItem,
@@ -248,10 +252,6 @@ def flow_predict_hake_postprocessing(
     path_weight: str,
     mvbs_slice_mins: int = 20,
     prediction_slice_mins: int = 40,
-    start_time: str | None = None,
-    end_time: str | None = None,
-    require_complete_window: bool = True,
-    overwrite: bool = False,
     temperature: float = 0.5,
     softmax_threshold: float = 0.5,
     max_depth: float = 590.0,
@@ -261,41 +261,34 @@ def flow_predict_hake_postprocessing(
     file_prediction_csv: str = "prediction_files.csv",
 ) -> None:
     """Predict all newly ready windows, combining aligned MVBS slices."""
-    if overwrite and (start_time is None or end_time is None):
-        raise ValueError("overwrite=True requires explicit start_time and end_time")
-
     logger = get_run_logger()
+
     # Create persistent destinations before loading the model
     for directory in ["prediction", "EVR", "NASC"]:
         (Path(path_main) / directory).mkdir(parents=True, exist_ok=True)
+
     # Load available MVBS slices and prior prediction results for resume behavior
-    mvbs = read_manifest(
+    df_MVBS = read_manifest(
         Path(path_main) / file_MVBS_csv,
         MVBS_COLUMNS_POSTPROCESSING,
         ["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
     )
-    mvbs = mvbs[mvbs["MVBS_status"] == "completed"]
-    manifest_path = Path(path_main) / file_prediction_csv
-    manifest = read_manifest(
-        manifest_path,
-        PREDICTION_COLUMNS_POSTPROCESSING,
-        ["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
+    file_prediction_csv = Path(path_main) / file_prediction_csv
+    df_prediction = read_or_create_ledger(
+        ledger_path=file_prediction_csv,
+        columns=PREDICTION_COLUMNS_POSTPROCESSING,
+        date_columns=["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
+        builder=lambda: build_prediction_ledger(
+            df_MVBS,
+            mvbs_slice_mins,
+            prediction_slice_mins,
+        ),
     )
     # Assemble aligned prediction windows from completed MVBS slices
     planned = plan_prediction_slices(
-        mvbs,
-        mvbs_slice_mins=mvbs_slice_mins,
-        prediction_slice_mins=prediction_slice_mins,
-        require_complete_window=require_complete_window,
-        start_time=start_time,
-        end_time=end_time,
+        df_MVBS,
+        df_prediction,
     )
-    completed = set(manifest["prediction_filename_postfix"].astype(str))
-    planned = [
-        item
-        for item in planned
-        if overwrite or item.start_time.strftime("%Y%m%dT%H%M%S") not in completed
-    ]
     if not planned:
         logger.info("No newly ready prediction windows")
         return
@@ -338,26 +331,39 @@ def flow_predict_hake_postprocessing(
                 ),
                 nasc_settings,
             )
-            record = [
-                postfix,
+            idx = df_prediction.index[df_prediction["prediction_filename_postfix"] == postfix][0]
+            df_prediction.loc[
+                idx,
+                [
+                    "score_filename",
+                    "softmax_filename",
+                    "prediction_filename",
+                    "evr_filename",
+                    "first_ping_time",
+                    "last_ping_time",
+                    "prediction_status",
+                    "error",
+                ],
+            ] = [
                 result.score_filename,
                 result.softmax_filename,
                 result.prediction_filename,
                 result.evr_filename,
-                item.start_time,
-                item.end_time,
                 result.first_ping_time,
                 result.last_ping_time,
+                "completed",
+                "",
             ]
             # Persist after each window so a failed later window does not lose progress
-            matches = manifest.index[manifest["prediction_filename_postfix"] == postfix]
-            if len(matches):
-                manifest.loc[matches[0], PREDICTION_COLUMNS_POSTPROCESSING] = record
-            else:
-                manifest.loc[len(manifest), PREDICTION_COLUMNS_POSTPROCESSING] = record
-            write_manifest(manifest.sort_values("slice_start"), manifest_path)
+            write_manifest(df_prediction.sort_values("slice_start"), file_prediction_csv)
         except Exception as exc:
             errors.append(exc)
+            idx = df_prediction.index[df_prediction["prediction_filename_postfix"] == postfix][0]
+            df_prediction.loc[idx, ["prediction_status", "error"]] = [
+                "failed",
+                str(exc),
+            ]
+            write_manifest(df_prediction.sort_values("slice_start"), file_prediction_csv)
             logger.error("Prediction window %s failed: %s", item.start_time, exc)
     if errors:
         raise RuntimeError(f"{len(errors)} prediction windows failed")

--- a/src/echodataflow/flows/flows_predict_hake.py
+++ b/src/echodataflow/flows/flows_predict_hake.py
@@ -13,6 +13,8 @@ from prefect.states import Failed
 from echodataflow.utils.manifests import (
     MVBS_COLUMNS,
     PREDICTION_COLUMNS,
+    REALTIME_MVBS_COLUMNS,
+    REALTIME_PREDICTION_COLUMNS,
     filter_slices,
     read_manifest,
     write_manifest,
@@ -32,7 +34,6 @@ from echodataflow.utils.utils import get_slice_start_end_times, round_up_mins
 # Turn on verbose logging for echopype
 # otherwise all logging will be muted
 ep.utils.log.verbose()
-
 
 @flow(log_prints=True)
 async def flow_predict_hake(
@@ -115,56 +116,26 @@ async def flow_predict_hake(
     # Load Sv and MVBS info dataframes
     if not file_MVBS_csv.exists():
         raise ValueError("MVBS info csv does not exist, check create_MVBS flow!")
-    df_MVBS = pd.read_csv(
+    df_MVBS = read_manifest(
         file_MVBS_csv,
-        index_col=0,
-        date_format="ISO8601",
-        parse_dates=["first_ping_time", "last_ping_time"],
+        REALTIME_MVBS_COLUMNS,
+        ["first_ping_time", "last_ping_time"],
     )
-    # Convert last_ping_time and first_ping_time to UTC
-    if not df_MVBS.empty:
-        if df_MVBS["last_ping_time"].dt.tz is None:
-            df_MVBS["last_ping_time"] = df_MVBS["last_ping_time"].dt.tz_localize("UTC")
-        if df_MVBS["first_ping_time"].dt.tz is None:
-            df_MVBS["first_ping_time"] = df_MVBS["first_ping_time"].dt.tz_localize("UTC")
-    else:
+    if df_MVBS.empty:
         logger.info(
             "MVBS info csv is empty, create_MVBS flow may have just started! "
             "No prediction can be made, exiting flow."
         )
         return
 
-    if not file_prediction_csv.exists():
-        df_prediction = pd.DataFrame(
-            columns=[
-                "prediction_filename_postfix",
-                "score_filename",
-                "softmax_filename",
-                "prediction_filename",
-                "evr_filename",
-                "first_ping_time",
-                "last_ping_time",
-            ]
-        )
-        df_prediction.to_csv(file_prediction_csv)
-    else:
-        df_prediction = pd.read_csv(
-            file_prediction_csv,
-            index_col=0,
-            date_format="ISO8601",
-            parse_dates=["first_ping_time", "last_ping_time"],
-        )
-        # Convert last_ping_time and first_ping_time to UTC
-        # only allowable when dataframe is not empty
-        if len(df_prediction) != 0:
-            if df_prediction["last_ping_time"].dt.tz is None:
-                df_prediction["last_ping_time"] = df_prediction["last_ping_time"].dt.tz_localize(
-                    "UTC"
-                )
-            if df_prediction["first_ping_time"].dt.tz is None:
-                df_prediction["first_ping_time"] = df_prediction["first_ping_time"].dt.tz_localize(
-                    "UTC"
-                )
+    prediction_manifest_exists = file_prediction_csv.exists()
+    df_prediction = read_manifest(
+        file_prediction_csv,
+        REALTIME_PREDICTION_COLUMNS,
+        ["first_ping_time", "last_ping_time"],
+    )
+    if not prediction_manifest_exists:
+        write_manifest(df_prediction, file_prediction_csv)
 
     prediction_settings = PredictHakeSettings(
         model=model,
@@ -259,7 +230,7 @@ async def flow_predict_hake(
             logger.error(f"Error during prediction for slice {snum+1}: {e}")
 
         # Save updated prediction info dataframe
-        df_prediction.to_csv(file_prediction_csv, date_format="%Y-%m-%dT%H:%M:%S")
+        write_manifest(df_prediction, file_prediction_csv)
 
     # Set flow to Failed state if any errors occurred
     if len(errors) > 0:

--- a/src/echodataflow/flows/flows_predict_hake.py
+++ b/src/echodataflow/flows/flows_predict_hake.py
@@ -16,7 +16,6 @@ from echodataflow.utils.manifests import (
     MVBS_COLUMNS_REALTIME,
     PREDICTION_COLUMNS_REALTIME,
     filter_slices,
-    manifest_signature_changed,
     read_manifest,
     write_manifest,
 )
@@ -274,8 +273,9 @@ def flow_predict_hake_postprocessing(
     mvbs = read_manifest(
         Path(path_main) / file_MVBS_csv,
         MVBS_COLUMNS_POSTPROCESSING,
-        ["first_ping_time", "last_ping_time"],
+        ["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
     )
+    mvbs = mvbs[mvbs["MVBS_status"] == "completed"]
     manifest_path = Path(path_main) / file_prediction_csv
     manifest = read_manifest(
         manifest_path,
@@ -293,16 +293,11 @@ def flow_predict_hake_postprocessing(
         start_time,
         end_time,
     )
+    completed = set(manifest["prediction_filename_postfix"].astype(str))
     planned = [
         item
         for item in planned
-        if overwrite
-        or manifest_signature_changed(
-            manifest,
-            "prediction_filename_postfix",
-            item.start_time.strftime("%Y%m%dT%H%M%S"),
-            item.input_signature,
-        )
+        if overwrite or item.start_time.strftime("%Y%m%dT%H%M%S") not in completed
     ]
     if not planned:
         logger.info("No newly ready prediction windows")
@@ -356,7 +351,6 @@ def flow_predict_hake_postprocessing(
                 item.end_time,
                 result.first_ping_time,
                 result.last_ping_time,
-                item.input_signature,
             ]
             # Persist after each window so a failed later window does not lose progress
             matches = manifest.index[manifest["prediction_filename_postfix"] == postfix]

--- a/src/echodataflow/flows/flows_predict_hake.py
+++ b/src/echodataflow/flows/flows_predict_hake.py
@@ -1,4 +1,4 @@
-"""Flow orchestration for hake prediction and downstream NASC processing."""
+"""Flows for hake prediction and downstream NASC processing."""
 
 from __future__ import annotations
 

--- a/src/echodataflow/flows/flows_predict_hake.py
+++ b/src/echodataflow/flows/flows_predict_hake.py
@@ -261,6 +261,10 @@ def flow_predict_hake_postprocessing(
 ) -> None:
     """Predict all newly ready windows, combining aligned MVBS slices."""
     logger = get_run_logger()
+    file_MVBS_csv = Path(path_main) / file_MVBS_csv
+    if not file_MVBS_csv.exists():
+        logger.info("MVBS ledger does not yet exist")
+        return
 
     # Create persistent destinations before loading the model
     for directory in ["prediction", "EVR", "NASC"]:
@@ -268,7 +272,7 @@ def flow_predict_hake_postprocessing(
 
     # Load available MVBS slices and prior prediction results for resume behavior
     df_MVBS = read_manifest(
-        Path(path_main) / file_MVBS_csv,
+        file_MVBS_csv,
         MVBS_COLUMNS_POSTPROCESSING,
         ["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
     )

--- a/src/echodataflow/flows/flows_predict_hake.py
+++ b/src/echodataflow/flows/flows_predict_hake.py
@@ -359,10 +359,7 @@ def flow_predict_hake_postprocessing(
         except Exception as exc:
             errors.append(exc)
             idx = df_prediction.index[df_prediction["prediction_filename_postfix"] == postfix][0]
-            df_prediction.loc[idx, ["prediction_status", "error"]] = [
-                "failed",
-                str(exc),
-            ]
+            df_prediction.loc[idx, ["prediction_status", "error"]] = ["failed", str(exc)]
             write_manifest(df_prediction.sort_values("slice_start"), file_prediction_csv)
             logger.error("Prediction window %s failed: %s", item.start_time, exc)
     if errors:

--- a/src/echodataflow/flows/flows_predict_hake.py
+++ b/src/echodataflow/flows/flows_predict_hake.py
@@ -11,10 +11,10 @@ from prefect import flow, get_client, get_run_logger, runtime
 from prefect.states import Failed
 
 from echodataflow.utils.manifests import (
-    MVBS_COLUMNS,
-    PREDICTION_COLUMNS,
-    REALTIME_MVBS_COLUMNS,
-    REALTIME_PREDICTION_COLUMNS,
+    MVBS_COLUMNS_POSTPROCESSING,
+    PREDICTION_COLUMNS_POSTPROCESSING,
+    MVBS_COLUMNS_REALTIME,
+    PREDICTION_COLUMNS_REALTIME,
     filter_slices,
     read_manifest,
     write_manifest,
@@ -118,7 +118,7 @@ async def flow_predict_hake(
         raise ValueError("MVBS info csv does not exist, check create_MVBS flow!")
     df_MVBS = read_manifest(
         file_MVBS_csv,
-        REALTIME_MVBS_COLUMNS,
+        MVBS_COLUMNS_REALTIME,
         ["first_ping_time", "last_ping_time"],
     )
     if df_MVBS.empty:
@@ -131,7 +131,7 @@ async def flow_predict_hake(
     prediction_manifest_exists = file_prediction_csv.exists()
     df_prediction = read_manifest(
         file_prediction_csv,
-        REALTIME_PREDICTION_COLUMNS,
+        PREDICTION_COLUMNS_REALTIME,
         ["first_ping_time", "last_ping_time"],
     )
     if not prediction_manifest_exists:
@@ -268,13 +268,13 @@ def flow_predict_hake_postprocessing(
     # Load available MVBS slices and prior prediction results for resume behavior
     mvbs = read_manifest(
         Path(path_main) / file_MVBS_csv,
-        MVBS_COLUMNS,
+        MVBS_COLUMNS_POSTPROCESSING,
         ["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
     )
     manifest_path = Path(path_main) / file_prediction_csv
     manifest = read_manifest(
         manifest_path,
-        PREDICTION_COLUMNS,
+        PREDICTION_COLUMNS_POSTPROCESSING,
         ["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
     )
     # Assemble aligned prediction windows from completed MVBS slices
@@ -350,9 +350,9 @@ def flow_predict_hake_postprocessing(
             # Persist after each window so a failed later window does not lose progress
             matches = manifest.index[manifest["prediction_filename_postfix"] == postfix]
             if len(matches):
-                manifest.loc[matches[0], PREDICTION_COLUMNS] = record
+                manifest.loc[matches[0], PREDICTION_COLUMNS_POSTPROCESSING] = record
             else:
-                manifest.loc[len(manifest), PREDICTION_COLUMNS] = record
+                manifest.loc[len(manifest), PREDICTION_COLUMNS_POSTPROCESSING] = record
             write_manifest(manifest.sort_values("slice_start"), manifest_path)
         except Exception as exc:
             errors.append(exc)

--- a/src/echodataflow/flows/flows_predict_hake.py
+++ b/src/echodataflow/flows/flows_predict_hake.py
@@ -16,6 +16,7 @@ from echodataflow.utils.manifests import (
     MVBS_COLUMNS_REALTIME,
     PREDICTION_COLUMNS_REALTIME,
     filter_slices,
+    manifest_signature_changed,
     read_manifest,
     write_manifest,
 )
@@ -34,6 +35,7 @@ from echodataflow.utils.utils import get_slice_start_end_times, round_up_mins
 # Turn on verbose logging for echopype
 # otherwise all logging will be muted
 ep.utils.log.verbose()
+
 
 @flow(log_prints=True)
 async def flow_predict_hake(
@@ -139,9 +141,9 @@ async def flow_predict_hake(
 
     prediction_settings = PredictHakeSettings(
         model=model,
-        mvbs_directory=path_MVBS_zarr,
-        prediction_directory=path_prediction_zarr,
-        evr_directory=path_prediction_evr,
+        directory_MVBS=path_MVBS_zarr,
+        directory_prediction=path_prediction_zarr,
+        directory_evr=path_prediction_evr,
         temperature=temperature,
         softmax_threshold=softmax_threshold,
         max_depth=max_depth,
@@ -157,7 +159,7 @@ async def flow_predict_hake(
         MVBS_filenames = sorted(
             df_MVBS[
                 (pd.to_datetime(df_MVBS["last_ping_time"]) >= start_time[snum])
-                & (pd.to_datetime(df_MVBS["first_ping_time"]) <= end_time[snum])
+                & (pd.to_datetime(df_MVBS["first_ping_time"]) < end_time[snum])
             ]["MVBS_filename"].tolist()
         )
         logger.info(
@@ -184,7 +186,7 @@ async def flow_predict_hake(
                 PredictHakeWorkItem(
                     start_time=start_time[snum],
                     end_time=end_time[snum],
-                    mvbs_filenames=tuple(MVBS_filenames),
+                    filenames_MVBS=tuple(MVBS_filenames),
                     filename_postfix=predict_filename_postfix,
                 ),
                 prediction_settings,
@@ -272,7 +274,7 @@ def flow_predict_hake_postprocessing(
     mvbs = read_manifest(
         Path(path_main) / file_MVBS_csv,
         MVBS_COLUMNS_POSTPROCESSING,
-        ["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
+        ["first_ping_time", "last_ping_time"],
     )
     manifest_path = Path(path_main) / file_prediction_csv
     manifest = read_manifest(
@@ -291,11 +293,16 @@ def flow_predict_hake_postprocessing(
         start_time,
         end_time,
     )
-    existing = set(manifest["prediction_filename_postfix"]) if not overwrite else set()
     planned = [
         item
         for item in planned
-        if item.start_time.strftime("%Y%m%dT%H%M%S") not in existing
+        if overwrite
+        or manifest_signature_changed(
+            manifest,
+            "prediction_filename_postfix",
+            item.start_time.strftime("%Y%m%dT%H%M%S"),
+            item.input_signature,
+        )
     ]
     if not planned:
         logger.info("No newly ready prediction windows")
@@ -305,9 +312,9 @@ def flow_predict_hake_postprocessing(
     model = get_hake_model(path_weight)
     prediction_settings = PredictHakeSettings(
         model=model,
-        mvbs_directory=str(Path(path_main) / "MVBS"),
-        prediction_directory=str(Path(path_main) / "prediction"),
-        evr_directory=str(Path(path_main) / "EVR"),
+        directory_MVBS=str(Path(path_main) / "MVBS"),
+        directory_prediction=str(Path(path_main) / "prediction"),
+        directory_evr=str(Path(path_main) / "EVR"),
         temperature=temperature,
         softmax_threshold=softmax_threshold,
         max_depth=max_depth,
@@ -326,7 +333,7 @@ def flow_predict_hake_postprocessing(
                 PredictHakeWorkItem(
                     start_time=item.start_time,
                     end_time=item.end_time,
-                    mvbs_filenames=item.filenames,
+                    filenames_MVBS=item.filenames,
                     filename_postfix=postfix,
                 ),
                 prediction_settings,
@@ -349,6 +356,7 @@ def flow_predict_hake_postprocessing(
                 item.end_time,
                 result.first_ping_time,
                 result.last_ping_time,
+                item.input_signature,
             ]
             # Persist after each window so a failed later window does not lose progress
             matches = manifest.index[manifest["prediction_filename_postfix"] == postfix]

--- a/src/echodataflow/flows/flows_simulation.py
+++ b/src/echodataflow/flows/flows_simulation.py
@@ -13,12 +13,12 @@ from botocore.config import Config
 from prefect import flow, runtime
 from prefect.variables import Variable
 
-from echodataflow.operations.operations_simulation import (
+from echodataflow.operations.operations_storage import (
     S3CopyResult,
     S3CopySettings,
     S3CopyWorkItem,
 )
-from echodataflow.tasks.tasks_simulation import task_copy_s3_file
+from echodataflow.tasks.tasks_storage import task_copy_s3_file
 
 
 def _var_key(prefix: str) -> str:

--- a/src/echodataflow/operations/operations_acoustics.py
+++ b/src/echodataflow/operations/operations_acoustics.py
@@ -35,8 +35,8 @@ class RawToSvSettings:
 class RawToSvResult:
     """Metadata describing one successfully created Sv store."""
 
-    raw_filename: str
-    sv_filename: str
+    filename_raw: str
+    filename_Sv: str
     first_ping_time: pd.Timestamp
     last_ping_time: pd.Timestamp
 
@@ -76,8 +76,8 @@ def convert_raw_to_Sv(
     )
 
     return RawToSvResult(
-        raw_filename=raw_path.name,
-        sv_filename=output_path.name,
+        filename_raw=raw_path.name,
+        filename_Sv=output_path.name,
         first_ping_time=pd.to_datetime(ds_sv["ping_time"][0].values),
         last_ping_time=pd.to_datetime(ds_sv["ping_time"][-1].values),
     )

--- a/src/echodataflow/operations/operations_acoustics.py
+++ b/src/echodataflow/operations/operations_acoustics.py
@@ -105,11 +105,12 @@ class CreateMVBSSettings:
 
 @dataclass(frozen=True)
 class CreateMVBSResult:
-    """Metadata describing one successfully created MVBS slice."""
+    """Metadata describing one attempted MVBS slice."""
 
     mvbs_filename: str
-    first_ping_time: pd.Timestamp
-    last_ping_time: pd.Timestamp
+    first_ping_time: pd.Timestamp | None
+    last_ping_time: pd.Timestamp | None
+    has_data: bool = True
 
 
 def create_MVBS(
@@ -134,6 +135,15 @@ def create_MVBS(
         # slice start/end, end exclusive
         ping_time=slice(start_time, end_time - pd.to_timedelta("1nanoseconds"))
     )
+
+    # Return normally when the selected inputs contain no pings for this slice
+    if ds_Sv.sizes.get("ping_time", 0) == 0:
+        return CreateMVBSResult(
+            mvbs_filename=item.mvbs_filename,
+            first_ping_time=None,
+            last_ping_time=None,
+            has_data=False,
+        )
 
     # Compute MVBS for the slice
     ds_MVBS = ep.commongrid.compute_MVBS(

--- a/src/echodataflow/operations/operations_postprocessing.py
+++ b/src/echodataflow/operations/operations_postprocessing.py
@@ -1,0 +1,143 @@
+"""Pure planning helpers for batch acoustic post-processing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class PlannedSlice:
+    """A time window and the files that overlap it."""
+
+    start_time: pd.Timestamp
+    end_time: pd.Timestamp
+    filenames: tuple[str, ...]
+    is_partial: bool = False
+
+
+def _utc(value) -> pd.Timestamp:
+    return pd.to_datetime(value, utc=True)
+
+
+def _interval_floor(value, minutes: int) -> pd.Timestamp:
+    if minutes <= 0:
+        raise ValueError("slice length must be greater than zero")
+    return _utc(value).floor(f"{minutes}min")
+
+
+def plan_mvbs_slices(
+    raw_processing: pd.DataFrame,
+    sv_files: pd.DataFrame,
+    slice_mins: int = 20,
+) -> list[PlannedSlice]:
+    """Return MVBS slices whose registered raw inputs are complete.
+
+    A slice is sealed only after the completion watermark has reached its end.
+    Failed or pending raw files whose source timestamps fall in the slice keep it
+    from becoming ready.
+    """
+    if raw_processing.empty or sv_files.empty:
+        return []
+
+    raw = raw_processing.copy()
+    sv = sv_files.copy()
+    raw["timestamp"] = pd.to_datetime(raw["timestamp"], utc=True)
+    sv["first_ping_time"] = pd.to_datetime(sv["first_ping_time"], utc=True)
+    sv["last_ping_time"] = pd.to_datetime(sv["last_ping_time"], utc=True)
+
+    completed = raw[raw["status"] == "completed"]
+    if completed.empty:
+        return []
+
+    # The watermark seals only intervals ending before the latest completed input
+    completed_keys = set(completed["s3_path"].astype(str))
+    watermark = completed["timestamp"].max()
+    duration = pd.Timedelta(minutes=slice_mins)
+    first = _interval_floor(sv["first_ping_time"].min(), slice_mins)
+    last_end = _interval_floor(watermark, slice_mins)
+    coverage_start = sv["first_ping_time"].min()
+    coverage_end = sv["last_ping_time"].max()
+
+    slices: list[PlannedSlice] = []
+    start = first
+    while start + duration <= last_end:
+        end = start + duration
+        # Include the preceding raw file because it may cross the slice boundary
+        expected = raw[(raw["timestamp"] >= start) & (raw["timestamp"] < end)]
+        predecessor = raw[raw["timestamp"] < start].sort_values("timestamp").tail(1)
+        if not predecessor.empty:
+            expected = pd.concat([predecessor, expected], ignore_index=True)
+        expected_keys = set(expected["s3_path"].astype(str))
+        if expected_keys and expected_keys.issubset(completed_keys):
+            # Pass every converted Sv store that overlaps the half-open slice
+            overlapping = sv[
+                (sv["last_ping_time"] >= start) & (sv["first_ping_time"] < end)
+            ].sort_values("first_ping_time")
+            if not overlapping.empty:
+                slices.append(
+                    PlannedSlice(
+                        start_time=start,
+                        end_time=end,
+                        filenames=tuple(overlapping["Sv_filename"].astype(str)),
+                        is_partial=coverage_start > start or coverage_end < end,
+                    )
+                )
+        start = end
+    return slices
+
+
+def plan_prediction_slices(
+    mvbs_files: pd.DataFrame,
+    mvbs_slice_mins: int = 20,
+    prediction_slice_mins: int = 40,
+    require_complete_window: bool = True,
+) -> list[PlannedSlice]:
+    """Group completed MVBS slices into aligned prediction windows."""
+    if prediction_slice_mins % mvbs_slice_mins != 0:
+        raise ValueError("prediction_slice_mins must be a multiple of mvbs_slice_mins")
+    if mvbs_files.empty:
+        return []
+
+    mvbs = mvbs_files.copy()
+    mvbs["slice_start"] = pd.to_datetime(mvbs["slice_start"], utc=True)
+    mvbs["slice_end"] = pd.to_datetime(mvbs["slice_end"], utc=True)
+    # Align every prediction window to a fixed UTC interval boundary
+    duration = pd.Timedelta(minutes=prediction_slice_mins)
+    expected_count = prediction_slice_mins // mvbs_slice_mins
+    first = _interval_floor(mvbs["slice_start"].min(), prediction_slice_mins)
+    final_end = _interval_floor(mvbs["slice_end"].max(), prediction_slice_mins)
+
+    slices: list[PlannedSlice] = []
+    start = first
+    while start + duration <= final_end:
+        end = start + duration
+        # Select the smaller MVBS slices fully contained in this prediction window
+        contributing = mvbs[
+            (mvbs["slice_start"] >= start) & (mvbs["slice_end"] <= end)
+        ].sort_values("slice_start")
+        starts = set(contributing["slice_start"])
+        expected_starts = {
+            start + pd.Timedelta(minutes=mvbs_slice_mins * n) for n in range(expected_count)
+        }
+        # Completeness requires every expected aligned MVBS start exactly once
+        complete = len(contributing) == expected_count and starts == expected_starts
+        partial = False
+        if "is_partial" in contributing:
+            partial = (
+                contributing["is_partial"]
+                .map(lambda value: str(value).strip().lower() in {"true", "1", "yes"})
+                .any()
+            )
+        if not contributing.empty and (not require_complete_window or (complete and not partial)):
+            slices.append(
+                PlannedSlice(
+                    start_time=start,
+                    end_time=end,
+                    filenames=tuple(contributing["MVBS_filename"].astype(str)),
+                    is_partial=not complete or bool(partial),
+                )
+            )
+        start = end
+    return slices

--- a/src/echodataflow/operations/operations_postprocessing.py
+++ b/src/echodataflow/operations/operations_postprocessing.py
@@ -109,7 +109,7 @@ def build_input_signature(
     return hashlib.sha256(serialized.encode()).hexdigest()
 
 
-def build_sv_ledger(raw_files: pd.DataFrame) -> pd.DataFrame:
+def build_Sv_ledger(raw_files: pd.DataFrame) -> pd.DataFrame:
     """Build the fixed post-processing Sv ledger from the complete raw list."""
     required = {"s3_path"}
     if not required.issubset(raw_files.columns):
@@ -137,12 +137,12 @@ def build_sv_ledger(raw_files: pd.DataFrame) -> pd.DataFrame:
     return ledger.sort_values("timestamp").reset_index(drop=True)
 
 
-def build_mvbs_ledger(sv_ledger: pd.DataFrame, slice_mins: int = 20) -> pd.DataFrame:
+def build_MVBS_ledger(ledger_Sv: pd.DataFrame, slice_mins: int = 20) -> pd.DataFrame:
     """Preplan every MVBS slice and its required raw files."""
-    if sv_ledger.empty:
+    if ledger_Sv.empty:
         return pd.DataFrame(columns=MVBS_COLUMNS_POSTPROCESSING)
 
-    df_Sv = sv_ledger.copy()
+    df_Sv = ledger_Sv.copy()
     df_Sv["timestamp"] = pd.to_datetime(df_Sv["timestamp"], utc=True)
     duration = pd.Timedelta(minutes=slice_mins)
     final_end = df_Sv["timestamp"].max().floor(f"{slice_mins}min") + duration
@@ -179,14 +179,14 @@ def build_mvbs_ledger(sv_ledger: pd.DataFrame, slice_mins: int = 20) -> pd.DataF
 
 
 def build_prediction_ledger(
-    mvbs_ledger: pd.DataFrame,
+    ledger_MVBS: pd.DataFrame,
     prediction_slice_mins: int = 40,
 ) -> pd.DataFrame:
     """Preplan every prediction window and its required MVBS slices."""
-    if mvbs_ledger.empty:
+    if ledger_MVBS.empty:
         return pd.DataFrame(columns=PREDICTION_COLUMNS_POSTPROCESSING)
 
-    df_MVBS = mvbs_ledger.copy()
+    df_MVBS = ledger_MVBS.copy()
     df_MVBS["slice_start"] = pd.to_datetime(df_MVBS["slice_start"], utc=True)
     df_MVBS["slice_end"] = pd.to_datetime(df_MVBS["slice_end"], utc=True)
     windows = generate_aligned_windows(
@@ -240,15 +240,15 @@ def read_or_create_ledger(
 
 
 def plan_mvbs_slices(
-    sv_ledger: pd.DataFrame,
-    mvbs_ledger: pd.DataFrame,
+    ledger_Sv: pd.DataFrame,
+    ledger_MVBS: pd.DataFrame,
 ) -> list[PlannedSlice]:
     """Return pending MVBS slices whose required raw conversions are complete."""
-    if sv_ledger.empty or mvbs_ledger.empty:
+    if ledger_Sv.empty or ledger_MVBS.empty:
         return []
 
-    df_Sv = sv_ledger.copy()
-    df_MVBS = mvbs_ledger.copy()
+    df_Sv = ledger_Sv.copy()
+    df_MVBS = ledger_MVBS.copy()
 
     # Ensure datetime columns are in UTC
     df_Sv["first_ping_time"] = pd.to_datetime(df_Sv["first_ping_time"], utc=True)
@@ -286,15 +286,17 @@ def plan_mvbs_slices(
 
 
 def plan_prediction_slices(
-    mvbs_ledger: pd.DataFrame,
-    prediction_ledger: pd.DataFrame,
+    ledger_MVBS: pd.DataFrame,
+    ledger_prediction: pd.DataFrame,
 ) -> list[PlannedSlice]:
     """Return pending prediction windows whose required MVBS slices are ready."""
-    if mvbs_ledger.empty or prediction_ledger.empty:
+    if ledger_MVBS.empty or ledger_prediction.empty:
         return []
 
-    df_MVBS = mvbs_ledger.copy()
-    df_prediction = prediction_ledger.copy()
+    df_MVBS = ledger_MVBS.copy()
+    df_prediction = ledger_prediction.copy()
+
+    # Ensure datetime columns are in UTC
     df_prediction["slice_start"] = pd.to_datetime(df_prediction["slice_start"], utc=True)
     df_prediction["slice_end"] = pd.to_datetime(df_prediction["slice_end"], utc=True)
 

--- a/src/echodataflow/operations/operations_postprocessing.py
+++ b/src/echodataflow/operations/operations_postprocessing.py
@@ -182,8 +182,6 @@ def build_prediction_ledger(
     prediction_slice_mins: int = 40,
 ) -> pd.DataFrame:
     """Preplan every prediction window and its required MVBS slices."""
-    if prediction_slice_mins % mvbs_slice_mins != 0:
-        raise ValueError("prediction_slice_mins must be a multiple of mvbs_slice_mins")
     if mvbs_ledger.empty:
         return pd.DataFrame()
 
@@ -198,10 +196,14 @@ def build_prediction_ledger(
 
     records = []
     for window in windows:
-        required = df_MVBS[
-            (df_MVBS["slice_start"] >= window.start_time)
-            & (df_MVBS["slice_start"] < window.end_time)
-        ].sort_values("slice_start")
+        required = filter_time_range(
+            df=df_MVBS,
+            column_start_time="slice_start",
+            column_end_time="slice_end",
+            start_time=window.start_time,
+            end_time=window.end_time,
+            include_exact_start_time=False,
+        )
         records.append(
             {
                 "prediction_filename_postfix": window.start_time.strftime("%Y%m%dT%H%M%S"),

--- a/src/echodataflow/operations/operations_postprocessing.py
+++ b/src/echodataflow/operations/operations_postprocessing.py
@@ -6,12 +6,11 @@ import hashlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable
 
 import pandas as pd
 
 from echodataflow.utils.manifests import (
-    MVBS_COLUMNS_POSTPROCESSING,
-    SV_COLUMNS_POSTPROCESSING,
     filter_time_range,
     read_manifest,
     write_manifest,
@@ -177,34 +176,19 @@ def build_mvbs_ledger(sv_ledger: pd.DataFrame, slice_mins: int = 20) -> pd.DataF
     return pd.DataFrame.from_records(records)
 
 
-def read_or_create_sv_ledger(path_raw_list: str, ledger_path: Path) -> pd.DataFrame:
-    """Load the Sv ledger or initialize it from the complete raw file list."""
-    if ledger_path.exists():
-        return read_manifest(
-            ledger_path,
-            SV_COLUMNS_POSTPROCESSING,
-            ["timestamp", "first_ping_time", "last_ping_time"],
-        )
-
-    ledger = build_sv_ledger(pd.read_csv(path_raw_list))
-    write_manifest(ledger, ledger_path)
-    return ledger
-
-
-def read_or_create_mvbs_ledger(
+def read_or_create_ledger(
     ledger_path: Path,
-    sv_ledger: pd.DataFrame,
-    slice_mins: int,
+    columns: list[str],
+    date_columns: list[str],
+    builder: Callable[[], pd.DataFrame],
 ) -> pd.DataFrame:
-    """Load the MVBS ledger or initialize it based on the Sv ledger."""
+    """Load a ledger or create it with the supplied builder."""
     if ledger_path.exists():
         return read_manifest(
-            ledger_path,
-            MVBS_COLUMNS_POSTPROCESSING,
-            ["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
+            path=ledger_path, columns=columns, date_columns=date_columns
         )
 
-    ledger = build_mvbs_ledger(sv_ledger, slice_mins)
+    ledger = builder()
     write_manifest(ledger, ledger_path)
     return ledger
 
@@ -245,9 +229,7 @@ def plan_mvbs_slices(
             PlannedSlice(
                 start_time=row.slice_start,
                 end_time=row.slice_end,
-                filenames=tuple(
-                    required_Sv.sort_values("timestamp")["Sv_filename"].astype(str)
-                ),
+                filenames=tuple(required_Sv.sort_values("timestamp")["Sv_filename"].astype(str)),
                 is_partial=(
                     required_Sv["first_ping_time"].min() > row.slice_start
                     or required_Sv["last_ping_time"].max() < row.slice_end

--- a/src/echodataflow/operations/operations_postprocessing.py
+++ b/src/echodataflow/operations/operations_postprocessing.py
@@ -258,7 +258,7 @@ def plan_mvbs_slices(
     slices: list[PlannedSlice] = []
     for row in df_MVBS.itertuples(index=False):
         # Skip slices that have already been created successfully
-        if row.MVBS_status == "completed":
+        if row.MVBS_status in {"completed", "no_data"}:
             continue
 
         required_raw = json.loads(row.raw_filenames)

--- a/src/echodataflow/operations/operations_postprocessing.py
+++ b/src/echodataflow/operations/operations_postprocessing.py
@@ -17,6 +17,14 @@ class PlannedSlice:
     is_partial: bool = False
 
 
+@dataclass(frozen=True)
+class TimeWindow:
+    """One aligned half-open time interval."""
+
+    start_time: pd.Timestamp
+    end_time: pd.Timestamp
+
+
 def _utc(value) -> pd.Timestamp:
     return pd.to_datetime(value, utc=True)
 
@@ -25,6 +33,47 @@ def _interval_floor(value, minutes: int) -> pd.Timestamp:
     if minutes <= 0:
         raise ValueError("slice length must be greater than zero")
     return _utc(value).floor(f"{minutes}min")
+
+
+def generate_aligned_windows(
+    first_time,
+    last_time,
+    window_mins: int,
+) -> list[TimeWindow]:
+    """Generate complete UTC-aligned windows between two timestamps."""
+    duration = pd.Timedelta(minutes=window_mins)
+    start = _interval_floor(first_time, window_mins)
+    final_end = _interval_floor(last_time, window_mins)
+
+    windows: list[TimeWindow] = []
+    while start + duration <= final_end:
+        windows.append(TimeWindow(start_time=start, end_time=start + duration))
+        start += duration
+    return windows
+
+
+def select_overlapping_records(
+    records: pd.DataFrame,
+    window: TimeWindow,
+    start_column: str,
+    end_column: str,
+) -> pd.DataFrame:
+    """Select records whose time coverage overlaps a window."""
+    return records[
+        (records[end_column] >= window.start_time) & (records[start_column] < window.end_time)
+    ]
+
+
+def select_contained_records(
+    records: pd.DataFrame,
+    window: TimeWindow,
+    start_column: str,
+    end_column: str,
+) -> pd.DataFrame:
+    """Select records fully contained within a window."""
+    return records[
+        (records[start_column] >= window.start_time) & (records[end_column] <= window.end_time)
+    ]
 
 
 def plan_mvbs_slices(
@@ -54,37 +103,43 @@ def plan_mvbs_slices(
     # The watermark seals only intervals ending before the latest completed input
     completed_keys = set(completed["s3_path"].astype(str))
     watermark = completed["timestamp"].max()
-    duration = pd.Timedelta(minutes=slice_mins)
-    first = _interval_floor(sv["first_ping_time"].min(), slice_mins)
-    last_end = _interval_floor(watermark, slice_mins)
     coverage_start = sv["first_ping_time"].min()
     coverage_end = sv["last_ping_time"].max()
 
     slices: list[PlannedSlice] = []
-    start = first
-    while start + duration <= last_end:
-        end = start + duration
+    windows = generate_aligned_windows(
+        sv["first_ping_time"].min(),
+        watermark,
+        slice_mins,
+    )
+    for window in windows:
         # Include the preceding raw file because it may cross the slice boundary
-        expected = raw[(raw["timestamp"] >= start) & (raw["timestamp"] < end)]
-        predecessor = raw[raw["timestamp"] < start].sort_values("timestamp").tail(1)
+        expected = raw[
+            (raw["timestamp"] >= window.start_time) & (raw["timestamp"] < window.end_time)
+        ]
+        predecessor = raw[raw["timestamp"] < window.start_time].sort_values("timestamp").tail(1)
         if not predecessor.empty:
             expected = pd.concat([predecessor, expected], ignore_index=True)
         expected_keys = set(expected["s3_path"].astype(str))
         if expected_keys and expected_keys.issubset(completed_keys):
             # Pass every converted Sv store that overlaps the half-open slice
-            overlapping = sv[
-                (sv["last_ping_time"] >= start) & (sv["first_ping_time"] < end)
-            ].sort_values("first_ping_time")
+            overlapping = select_overlapping_records(
+                sv,
+                window,
+                "first_ping_time",
+                "last_ping_time",
+            ).sort_values("first_ping_time")
             if not overlapping.empty:
                 slices.append(
                     PlannedSlice(
-                        start_time=start,
-                        end_time=end,
+                        start_time=window.start_time,
+                        end_time=window.end_time,
                         filenames=tuple(overlapping["Sv_filename"].astype(str)),
-                        is_partial=coverage_start > start or coverage_end < end,
+                        is_partial=(
+                            coverage_start > window.start_time or coverage_end < window.end_time
+                        ),
                     )
                 )
-        start = end
     return slices
 
 
@@ -103,23 +158,27 @@ def plan_prediction_slices(
     mvbs = mvbs_files.copy()
     mvbs["slice_start"] = pd.to_datetime(mvbs["slice_start"], utc=True)
     mvbs["slice_end"] = pd.to_datetime(mvbs["slice_end"], utc=True)
-    # Align every prediction window to a fixed UTC interval boundary
-    duration = pd.Timedelta(minutes=prediction_slice_mins)
     expected_count = prediction_slice_mins // mvbs_slice_mins
-    first = _interval_floor(mvbs["slice_start"].min(), prediction_slice_mins)
-    final_end = _interval_floor(mvbs["slice_end"].max(), prediction_slice_mins)
 
     slices: list[PlannedSlice] = []
-    start = first
-    while start + duration <= final_end:
-        end = start + duration
+    # Align every prediction window to a fixed UTC interval boundary
+    windows = generate_aligned_windows(
+        mvbs["slice_start"].min(),
+        mvbs["slice_end"].max(),
+        prediction_slice_mins,
+    )
+    for window in windows:
         # Select the smaller MVBS slices fully contained in this prediction window
-        contributing = mvbs[
-            (mvbs["slice_start"] >= start) & (mvbs["slice_end"] <= end)
-        ].sort_values("slice_start")
+        contributing = select_contained_records(
+            mvbs,
+            window,
+            "slice_start",
+            "slice_end",
+        ).sort_values("slice_start")
         starts = set(contributing["slice_start"])
         expected_starts = {
-            start + pd.Timedelta(minutes=mvbs_slice_mins * n) for n in range(expected_count)
+            window.start_time + pd.Timedelta(minutes=mvbs_slice_mins * n)
+            for n in range(expected_count)
         }
         # Completeness requires every expected aligned MVBS start exactly once
         complete = len(contributing) == expected_count and starts == expected_starts
@@ -133,11 +192,10 @@ def plan_prediction_slices(
         if not contributing.empty and (not require_complete_window or (complete and not partial)):
             slices.append(
                 PlannedSlice(
-                    start_time=start,
-                    end_time=end,
+                    start_time=window.start_time,
+                    end_time=window.end_time,
                     filenames=tuple(contributing["MVBS_filename"].astype(str)),
                     is_partial=not complete or bool(partial),
                 )
             )
-        start = end
     return slices

--- a/src/echodataflow/operations/operations_postprocessing.py
+++ b/src/echodataflow/operations/operations_postprocessing.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass
 
 import pandas as pd
@@ -15,6 +17,7 @@ class PlannedSlice:
     end_time: pd.Timestamp
     filenames: tuple[str, ...]
     is_partial: bool = False
+    input_signature: str = ""
 
 
 @dataclass(frozen=True)
@@ -76,9 +79,36 @@ def select_contained_records(
     ]
 
 
+def build_input_signature(
+    records: pd.DataFrame,
+    columns: list[str],
+    window: TimeWindow,
+) -> str:
+    """Create a deterministic fingerprint of window inputs and their metadata."""
+
+    def fix_value(value):
+        if pd.isna(value):
+            return None
+        if isinstance(value, pd.Timestamp):
+            return value.isoformat()
+        return str(value)
+
+    rows = [
+        {column: fix_value(row[column]) for column in columns}
+        for _, row in records.sort_values(columns[0]).iterrows()
+    ]
+    payload = {
+        "window_start": window.start_time.isoformat(),
+        "window_end": window.end_time.isoformat(),
+        "inputs": rows,
+    }
+    serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(serialized.encode()).hexdigest()
+
+
 def plan_mvbs_slices(
-    raw_processing: pd.DataFrame,
-    sv_files: pd.DataFrame,
+    df_raw_in: pd.DataFrame,
+    df_Sv_in: pd.DataFrame,
     slice_mins: int = 20,
 ) -> list[PlannedSlice]:
     """Return MVBS slices whose registered raw inputs are complete.
@@ -87,49 +117,54 @@ def plan_mvbs_slices(
     Failed or pending raw files whose source timestamps fall in the slice keep it
     from becoming ready.
     """
-    if raw_processing.empty or sv_files.empty:
+    if df_raw_in.empty or df_Sv_in.empty:
         return []
 
-    raw = raw_processing.copy()
-    sv = sv_files.copy()
-    raw["timestamp"] = pd.to_datetime(raw["timestamp"], utc=True)
-    sv["first_ping_time"] = pd.to_datetime(sv["first_ping_time"], utc=True)
-    sv["last_ping_time"] = pd.to_datetime(sv["last_ping_time"], utc=True)
+    df_raw = df_raw_in.copy()
+    df_Sv = df_Sv_in.copy()
+    df_raw["timestamp"] = pd.to_datetime(df_raw["timestamp"], utc=True)
+    df_Sv["first_ping_time"] = pd.to_datetime(df_Sv["first_ping_time"], utc=True)
+    df_Sv["last_ping_time"] = pd.to_datetime(df_Sv["last_ping_time"], utc=True)
 
-    completed = raw[raw["status"] == "completed"]
-    if completed.empty:
+    df_completed = df_raw[df_raw["status"] == "completed"]
+    if df_completed.empty:
         return []
 
     # The watermark seals only intervals ending before the latest completed input
-    completed_keys = set(completed["s3_path"].astype(str))
-    watermark = completed["timestamp"].max()
-    coverage_start = sv["first_ping_time"].min()
-    coverage_end = sv["last_ping_time"].max()
+    completed_keys = set(df_completed["s3_path"].astype(str))
+    watermark = df_completed["timestamp"].max()
+    coverage_start = df_Sv["first_ping_time"].min()
+    coverage_end = df_Sv["last_ping_time"].max()
 
     slices: list[PlannedSlice] = []
     windows = generate_aligned_windows(
-        sv["first_ping_time"].min(),
+        df_Sv["first_ping_time"].min(),
         watermark,
         slice_mins,
     )
     for window in windows:
         # Include the preceding raw file because it may cross the slice boundary
-        expected = raw[
-            (raw["timestamp"] >= window.start_time) & (raw["timestamp"] < window.end_time)
+        expected = df_raw[
+            (df_raw["timestamp"] >= window.start_time) & (df_raw["timestamp"] < window.end_time)
         ]
-        predecessor = raw[raw["timestamp"] < window.start_time].sort_values("timestamp").tail(1)
+        predecessor = df_raw[df_raw["timestamp"] < window.start_time].sort_values("timestamp").tail(1)
         if not predecessor.empty:
             expected = pd.concat([predecessor, expected], ignore_index=True)
         expected_keys = set(expected["s3_path"].astype(str))
         if expected_keys and expected_keys.issubset(completed_keys):
             # Pass every converted Sv store that overlaps the half-open slice
             overlapping = select_overlapping_records(
-                sv,
+                df_Sv,
                 window,
                 "first_ping_time",
                 "last_ping_time",
             ).sort_values("first_ping_time")
             if not overlapping.empty:
+                input_signature = build_input_signature(
+                    overlapping,
+                    ["Sv_filename", "first_ping_time", "last_ping_time"],
+                    window,
+                )
                 slices.append(
                     PlannedSlice(
                         start_time=window.start_time,
@@ -138,13 +173,14 @@ def plan_mvbs_slices(
                         is_partial=(
                             coverage_start > window.start_time or coverage_end < window.end_time
                         ),
+                        input_signature=input_signature,
                     )
                 )
     return slices
 
 
 def plan_prediction_slices(
-    mvbs_files: pd.DataFrame,
+    df_MVBS_in: pd.DataFrame,
     mvbs_slice_mins: int = 20,
     prediction_slice_mins: int = 40,
     require_complete_window: bool = True,
@@ -152,36 +188,31 @@ def plan_prediction_slices(
     """Group completed MVBS slices into aligned prediction windows."""
     if prediction_slice_mins % mvbs_slice_mins != 0:
         raise ValueError("prediction_slice_mins must be a multiple of mvbs_slice_mins")
-    if mvbs_files.empty:
+    if df_MVBS_in.empty:
         return []
 
-    mvbs = mvbs_files.copy()
-    mvbs["slice_start"] = pd.to_datetime(mvbs["slice_start"], utc=True)
-    mvbs["slice_end"] = pd.to_datetime(mvbs["slice_end"], utc=True)
+    df_MVBS = df_MVBS_in.copy()
+    df_MVBS["first_ping_time"] = pd.to_datetime(df_MVBS["first_ping_time"], utc=True)
+    df_MVBS["last_ping_time"] = pd.to_datetime(df_MVBS["last_ping_time"], utc=True)
     expected_count = prediction_slice_mins // mvbs_slice_mins
 
     slices: list[PlannedSlice] = []
-    # Align every prediction window to a fixed UTC interval boundary
+    # Derive prediction windows directly from the available ping-time coverage
     windows = generate_aligned_windows(
-        mvbs["slice_start"].min(),
-        mvbs["slice_end"].max(),
+        df_MVBS["first_ping_time"].min(),
+        df_MVBS["last_ping_time"].max().ceil(f"{prediction_slice_mins}min"),
         prediction_slice_mins,
     )
     for window in windows:
-        # Select the smaller MVBS slices fully contained in this prediction window
-        contributing = select_contained_records(
-            mvbs,
+        # Match the real-time flow's actual ping-time overlap selection
+        contributing = select_overlapping_records(
+            df_MVBS,
             window,
-            "slice_start",
-            "slice_end",
-        ).sort_values("slice_start")
-        starts = set(contributing["slice_start"])
-        expected_starts = {
-            window.start_time + pd.Timedelta(minutes=mvbs_slice_mins * n)
-            for n in range(expected_count)
-        }
-        # Completeness requires every expected aligned MVBS start exactly once
-        complete = len(contributing) == expected_count and starts == expected_starts
+            "first_ping_time",
+            "last_ping_time",
+        ).sort_values("first_ping_time")
+        # Optional completeness requires the expected number of non-partial inputs
+        complete = len(contributing) == expected_count
         partial = False
         if "is_partial" in contributing:
             partial = (
@@ -190,12 +221,22 @@ def plan_prediction_slices(
                 .any()
             )
         if not contributing.empty and (not require_complete_window or (complete and not partial)):
+            signature_columns = ["MVBS_filename", "first_ping_time", "last_ping_time"]
+            if "input_signature" in contributing:
+                # Propagate upstream Sv changes even when MVBS ping bounds stay fixed
+                signature_columns.append("input_signature")
+            input_signature = build_input_signature(
+                contributing,
+                signature_columns,
+                window,
+            )
             slices.append(
                 PlannedSlice(
                     start_time=window.start_time,
                     end_time=window.end_time,
                     filenames=tuple(contributing["MVBS_filename"].astype(str)),
                     is_partial=not complete or bool(partial),
+                    input_signature=input_signature,
                 )
             )
     return slices

--- a/src/echodataflow/operations/operations_postprocessing.py
+++ b/src/echodataflow/operations/operations_postprocessing.py
@@ -176,6 +176,51 @@ def build_mvbs_ledger(sv_ledger: pd.DataFrame, slice_mins: int = 20) -> pd.DataF
     return pd.DataFrame.from_records(records)
 
 
+def build_prediction_ledger(
+    mvbs_ledger: pd.DataFrame,
+    mvbs_slice_mins: int = 20,
+    prediction_slice_mins: int = 40,
+) -> pd.DataFrame:
+    """Preplan every prediction window and its required MVBS slices."""
+    if prediction_slice_mins % mvbs_slice_mins != 0:
+        raise ValueError("prediction_slice_mins must be a multiple of mvbs_slice_mins")
+    if mvbs_ledger.empty:
+        return pd.DataFrame()
+
+    df_MVBS = mvbs_ledger.copy()
+    df_MVBS["slice_start"] = pd.to_datetime(df_MVBS["slice_start"], utc=True)
+    df_MVBS["slice_end"] = pd.to_datetime(df_MVBS["slice_end"], utc=True)
+    windows = generate_aligned_windows(
+        df_MVBS["slice_start"].min(),
+        df_MVBS["slice_end"].max(),
+        prediction_slice_mins,
+    )
+
+    records = []
+    for window in windows:
+        required = df_MVBS[
+            (df_MVBS["slice_start"] >= window.start_time)
+            & (df_MVBS["slice_start"] < window.end_time)
+        ].sort_values("slice_start")
+        records.append(
+            {
+                "prediction_filename_postfix": window.start_time.strftime("%Y%m%dT%H%M%S"),
+                "slice_start": window.start_time,
+                "slice_end": window.end_time,
+                "MVBS_filenames": json.dumps(required["MVBS_filename"].tolist()),
+                "score_filename": pd.NA,
+                "softmax_filename": pd.NA,
+                "prediction_filename": pd.NA,
+                "evr_filename": pd.NA,
+                "first_ping_time": pd.NaT,
+                "last_ping_time": pd.NaT,
+                "prediction_status": "pending",
+                "error": "",
+            }
+        )
+    return pd.DataFrame.from_records(records)
+
+
 def read_or_create_ledger(
     ledger_path: Path,
     columns: list[str],
@@ -184,9 +229,7 @@ def read_or_create_ledger(
 ) -> pd.DataFrame:
     """Load a ledger or create it with the supplied builder."""
     if ledger_path.exists():
-        return read_manifest(
-            path=ledger_path, columns=columns, date_columns=date_columns
-        )
+        return read_manifest(path=ledger_path, columns=columns, date_columns=date_columns)
 
     ledger = builder()
     write_manifest(ledger, ledger_path)
@@ -240,70 +283,45 @@ def plan_mvbs_slices(
 
 
 def plan_prediction_slices(
-    df_MVBS_in: pd.DataFrame,
-    mvbs_slice_mins: int = 20,
-    prediction_slice_mins: int = 40,
-    require_complete_window: bool = True,
-    start_time: str | None = None,
-    end_time: str | None = None,
+    mvbs_ledger: pd.DataFrame,
+    prediction_ledger: pd.DataFrame,
 ) -> list[PlannedSlice]:
-    """Group completed MVBS slices into aligned prediction windows."""
-    if prediction_slice_mins % mvbs_slice_mins != 0:
-        raise ValueError("prediction_slice_mins must be a multiple of mvbs_slice_mins")
-    if df_MVBS_in.empty:
+    """Return pending prediction windows whose required MVBS slices are ready."""
+    if mvbs_ledger.empty or prediction_ledger.empty:
         return []
 
-    df_MVBS = df_MVBS_in.copy()
-    df_MVBS["first_ping_time"] = pd.to_datetime(df_MVBS["first_ping_time"], utc=True)
-    df_MVBS["last_ping_time"] = pd.to_datetime(df_MVBS["last_ping_time"], utc=True)
-    expected_count = prediction_slice_mins // mvbs_slice_mins
+    df_MVBS = mvbs_ledger.copy()
+    df_prediction = prediction_ledger.copy()
+    df_prediction["slice_start"] = pd.to_datetime(df_prediction["slice_start"], utc=True)
+    df_prediction["slice_end"] = pd.to_datetime(df_prediction["slice_end"], utc=True)
 
     slices: list[PlannedSlice] = []
-    # Derive prediction windows directly from the available ping-time coverage
-    windows = generate_aligned_windows(
-        first_time=df_MVBS["first_ping_time"].min(),
-        last_time=df_MVBS["last_ping_time"].max().ceil(f"{prediction_slice_mins}min"),
-        window_mins=prediction_slice_mins,
-    )
-    window_frame = pd.DataFrame(
-        {
-            "start_time": [window.start_time for window in windows],
-            "end_time": [window.end_time for window in windows],
-        }
-    )
-    # Filter the generated windows based on the specified time range
-    window_frame = filter_time_range(
-        df=window_frame,
-        column_start_time="start_time",
-        column_end_time="end_time",
-        start_time=start_time,
-        end_time=end_time,
-    )
-    for row in window_frame.itertuples(index=False):
-        window = TimeWindow(row.start_time, row.end_time)
-        # Match the real-time flow's actual ping-time overlap selection
-        contributing = select_overlapping_records(
-            df_MVBS,
-            window,
-            "first_ping_time",
-            "last_ping_time",
-        ).sort_values("first_ping_time")
-        # Optional completeness requires the expected number of non-partial inputs
-        complete = len(contributing) == expected_count
-        partial = False
-        if "is_partial" in contributing:
-            partial = (
-                contributing["is_partial"]
-                .map(lambda value: str(value).strip().lower() in {"true", "1", "yes"})
-                .any()
+    for row in df_prediction.itertuples(index=False):
+        if row.prediction_status == "completed":
+            continue
+
+        required_names = json.loads(row.MVBS_filenames)
+        required_MVBS = df_MVBS[df_MVBS["MVBS_filename"].isin(required_names)]
+        if len(required_MVBS) != len(required_names):
+            raise ValueError(f"Prediction ledger references unknown MVBS files: {required_names}")
+
+        if not required_MVBS["MVBS_status"].eq("completed").all():
+            continue
+
+        partial = (
+            required_MVBS["is_partial"]
+            .map(lambda value: str(value).strip().lower() in {"true", "1", "yes"})
+            .any()
+        )
+
+        slices.append(
+            PlannedSlice(
+                start_time=row.slice_start,
+                end_time=row.slice_end,
+                filenames=tuple(
+                    required_MVBS.sort_values("slice_start")["MVBS_filename"].astype(str)
+                ),
+                is_partial=bool(partial),
             )
-        if not contributing.empty and (not require_complete_window or (complete and not partial)):
-            slices.append(
-                PlannedSlice(
-                    start_time=window.start_time,
-                    end_time=window.end_time,
-                    filenames=tuple(contributing["MVBS_filename"].astype(str)),
-                    is_partial=not complete or bool(partial),
-                )
-            )
+        )
     return slices

--- a/src/echodataflow/operations/operations_postprocessing.py
+++ b/src/echodataflow/operations/operations_postprocessing.py
@@ -11,6 +11,8 @@ from typing import Callable
 import pandas as pd
 
 from echodataflow.utils.manifests import (
+    MVBS_COLUMNS_POSTPROCESSING,
+    PREDICTION_COLUMNS_POSTPROCESSING,
     filter_time_range,
     read_manifest,
     write_manifest,
@@ -138,7 +140,7 @@ def build_sv_ledger(raw_files: pd.DataFrame) -> pd.DataFrame:
 def build_mvbs_ledger(sv_ledger: pd.DataFrame, slice_mins: int = 20) -> pd.DataFrame:
     """Preplan every MVBS slice and its required raw files."""
     if sv_ledger.empty:
-        return pd.DataFrame()
+        return pd.DataFrame(columns=MVBS_COLUMNS_POSTPROCESSING)
 
     df_Sv = sv_ledger.copy()
     df_Sv["timestamp"] = pd.to_datetime(df_Sv["timestamp"], utc=True)
@@ -173,17 +175,16 @@ def build_mvbs_ledger(sv_ledger: pd.DataFrame, slice_mins: int = 20) -> pd.DataF
                 "error": "",
             }
         )
-    return pd.DataFrame.from_records(records)
+    return pd.DataFrame.from_records(records, columns=MVBS_COLUMNS_POSTPROCESSING)
 
 
 def build_prediction_ledger(
     mvbs_ledger: pd.DataFrame,
-    mvbs_slice_mins: int = 20,
     prediction_slice_mins: int = 40,
 ) -> pd.DataFrame:
     """Preplan every prediction window and its required MVBS slices."""
     if mvbs_ledger.empty:
-        return pd.DataFrame()
+        return pd.DataFrame(columns=PREDICTION_COLUMNS_POSTPROCESSING)
 
     df_MVBS = mvbs_ledger.copy()
     df_MVBS["slice_start"] = pd.to_datetime(df_MVBS["slice_start"], utc=True)
@@ -220,7 +221,7 @@ def build_prediction_ledger(
                 "error": "",
             }
         )
-    return pd.DataFrame.from_records(records)
+    return pd.DataFrame.from_records(records, columns=PREDICTION_COLUMNS_POSTPROCESSING)
 
 
 def read_or_create_ledger(

--- a/src/echodataflow/operations/operations_postprocessing.py
+++ b/src/echodataflow/operations/operations_postprocessing.py
@@ -12,6 +12,7 @@ import pandas as pd
 from echodataflow.utils.manifests import (
     MVBS_COLUMNS_POSTPROCESSING,
     SV_COLUMNS_POSTPROCESSING,
+    filter_time_range,
     read_manifest,
     write_manifest,
 )
@@ -140,23 +141,26 @@ def build_mvbs_ledger(sv_ledger: pd.DataFrame, slice_mins: int = 20) -> pd.DataF
     if sv_ledger.empty:
         return pd.DataFrame()
 
-    ledger = sv_ledger.copy()
-    ledger["timestamp"] = pd.to_datetime(ledger["timestamp"], utc=True)
+    df_Sv = sv_ledger.copy()
+    df_Sv["timestamp"] = pd.to_datetime(df_Sv["timestamp"], utc=True)
     duration = pd.Timedelta(minutes=slice_mins)
-    final_end = ledger["timestamp"].max().floor(f"{slice_mins}min") + duration
+    final_end = df_Sv["timestamp"].max().floor(f"{slice_mins}min") + duration
     windows = generate_aligned_windows(
-        ledger["timestamp"].min(),
+        df_Sv["timestamp"].min(),
         final_end,
         slice_mins,
     )
 
     records = []
     for window in windows:
-        required = ledger[
-            (ledger["timestamp"] >= window.start_time) & (ledger["timestamp"] < window.end_time)
-        ]
-        predecessor = ledger[ledger["timestamp"] < window.start_time].tail(1)
-        required = pd.concat([predecessor, required]).drop_duplicates("s3_path")
+        # Record the raw files required by this slice, including its predecessor
+        required = filter_time_range(
+            df=df_Sv,
+            column_start_time="timestamp",
+            column_end_time=None,
+            start_time=window.start_time,
+            end_time=window.end_time,
+        )
         records.append(
             {
                 "MVBS_filename": f"MVBS_{window.start_time:%Y%m%dT%H%M%S}.zarr",
@@ -224,6 +228,10 @@ def plan_mvbs_slices(
 
     slices: list[PlannedSlice] = []
     for row in df_MVBS.itertuples(index=False):
+        # Skip slices that have already been created successfully
+        if row.MVBS_status == "completed":
+            continue
+
         required_raw = json.loads(row.raw_filenames)
         required_Sv = df_Sv[df_Sv["raw_filename"].isin(required_raw)]
         if len(required_Sv) != len(required_raw):
@@ -233,23 +241,16 @@ def plan_mvbs_slices(
         if not required_Sv["raw2Sv_status"].eq("completed").all():
             continue
 
-        window = TimeWindow(row.slice_start, row.slice_end)
-        overlapping = select_overlapping_records(
-            required_Sv,
-            window,
-            "first_ping_time",
-            "last_ping_time",
-        ).sort_values("first_ping_time")
-        if overlapping.empty:
-            continue
         slices.append(
             PlannedSlice(
-                start_time=window.start_time,
-                end_time=window.end_time,
-                filenames=tuple(overlapping["Sv_filename"].astype(str)),
+                start_time=row.slice_start,
+                end_time=row.slice_end,
+                filenames=tuple(
+                    required_Sv.sort_values("timestamp")["Sv_filename"].astype(str)
+                ),
                 is_partial=(
-                    overlapping["first_ping_time"].min() > window.start_time
-                    or overlapping["last_ping_time"].max() < window.end_time
+                    required_Sv["first_ping_time"].min() > row.slice_start
+                    or required_Sv["last_ping_time"].max() < row.slice_end
                 ),
             )
         )
@@ -261,6 +262,8 @@ def plan_prediction_slices(
     mvbs_slice_mins: int = 20,
     prediction_slice_mins: int = 40,
     require_complete_window: bool = True,
+    start_time: str | None = None,
+    end_time: str | None = None,
 ) -> list[PlannedSlice]:
     """Group completed MVBS slices into aligned prediction windows."""
     if prediction_slice_mins % mvbs_slice_mins != 0:
@@ -280,7 +283,22 @@ def plan_prediction_slices(
         last_time=df_MVBS["last_ping_time"].max().ceil(f"{prediction_slice_mins}min"),
         window_mins=prediction_slice_mins,
     )
-    for window in windows:
+    window_frame = pd.DataFrame(
+        {
+            "start_time": [window.start_time for window in windows],
+            "end_time": [window.end_time for window in windows],
+        }
+    )
+    # Filter the generated windows based on the specified time range
+    window_frame = filter_time_range(
+        df=window_frame,
+        column_start_time="start_time",
+        column_end_time="end_time",
+        start_time=start_time,
+        end_time=end_time,
+    )
+    for row in window_frame.itertuples(index=False):
+        window = TimeWindow(row.start_time, row.end_time)
         # Match the real-time flow's actual ping-time overlap selection
         contributing = select_overlapping_records(
             df_MVBS,

--- a/src/echodataflow/operations/operations_postprocessing.py
+++ b/src/echodataflow/operations/operations_postprocessing.py
@@ -5,8 +5,17 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
+from pathlib import Path
 
 import pandas as pd
+
+from echodataflow.utils.manifests import (
+    MVBS_COLUMNS_POSTPROCESSING,
+    SV_COLUMNS_POSTPROCESSING,
+    read_manifest,
+    write_manifest,
+)
+from echodataflow.utils.utils import extract_datetime_from_filename
 
 
 @dataclass(frozen=True)
@@ -28,25 +37,17 @@ class TimeWindow:
     end_time: pd.Timestamp
 
 
-def _utc(value) -> pd.Timestamp:
-    return pd.to_datetime(value, utc=True)
-
-
-def _interval_floor(value, minutes: int) -> pd.Timestamp:
-    if minutes <= 0:
-        raise ValueError("slice length must be greater than zero")
-    return _utc(value).floor(f"{minutes}min")
-
-
 def generate_aligned_windows(
     first_time,
     last_time,
     window_mins: int,
 ) -> list[TimeWindow]:
     """Generate complete UTC-aligned windows between two timestamps."""
+    if window_mins <= 0:
+        raise ValueError("slice length must be greater than zero")
     duration = pd.Timedelta(minutes=window_mins)
-    start = _interval_floor(first_time, window_mins)
-    final_end = _interval_floor(last_time, window_mins)
+    start = pd.to_datetime(first_time, utc=True).floor(f"{window_mins}min")
+    final_end = pd.to_datetime(last_time, utc=True).floor(f"{window_mins}min")
 
     windows: list[TimeWindow] = []
     while start + duration <= final_end:
@@ -106,76 +107,152 @@ def build_input_signature(
     return hashlib.sha256(serialized.encode()).hexdigest()
 
 
-def plan_mvbs_slices(
-    df_raw_in: pd.DataFrame,
-    df_Sv_in: pd.DataFrame,
-    slice_mins: int = 20,
-) -> list[PlannedSlice]:
-    """Return MVBS slices whose registered raw inputs are complete.
+def build_sv_ledger(raw_files: pd.DataFrame) -> pd.DataFrame:
+    """Build the fixed post-processing Sv ledger from the complete raw list."""
+    required = {"s3_path"}
+    if not required.issubset(raw_files.columns):
+        raise ValueError(f"raw list must contain columns: {sorted(required)}")
 
-    A slice is sealed only after the completion watermark has reached its end.
-    Failed or pending raw files whose source timestamps fall in the slice keep it
-    from becoming ready.
-    """
-    if df_raw_in.empty or df_Sv_in.empty:
-        return []
+    ledger = raw_files[["s3_path"]].copy()
+    ledger["s3_path"] = ledger["s3_path"].astype(str)
+    ledger["raw_filename"] = ledger["s3_path"].map(lambda value: Path(value).name)
+    if ledger["s3_path"].duplicated().any():
+        raise ValueError("raw list contains duplicate S3 paths")
+    if ledger["raw_filename"].duplicated().any():
+        raise ValueError("raw list contains duplicate basenames")
 
-    df_raw = df_raw_in.copy()
-    df_Sv = df_Sv_in.copy()
-    df_raw["timestamp"] = pd.to_datetime(df_raw["timestamp"], utc=True)
-    df_Sv["first_ping_time"] = pd.to_datetime(df_Sv["first_ping_time"], utc=True)
-    df_Sv["last_ping_time"] = pd.to_datetime(df_Sv["last_ping_time"], utc=True)
+    ledger["timestamp"] = ledger["raw_filename"].map(extract_datetime_from_filename)
+    invalid = ledger.loc[ledger["timestamp"].isna(), "raw_filename"].tolist()
+    if invalid:
+        raise ValueError(f"Could not parse timestamps from raw filenames: {invalid}")
+    ledger["timestamp"] = pd.to_datetime(ledger["timestamp"], utc=True)
 
-    df_completed = df_raw[df_raw["status"] == "completed"]
-    if df_completed.empty:
-        return []
+    ledger["Sv_filename"] = pd.NA
+    ledger["raw2Sv_status"] = "pending"
+    ledger["first_ping_time"] = pd.NaT
+    ledger["last_ping_time"] = pd.NaT
+    ledger["error"] = ""
+    return ledger.sort_values("timestamp").reset_index(drop=True)
 
-    # The watermark seals only intervals ending before the latest completed input
-    completed_keys = set(df_completed["s3_path"].astype(str))
-    watermark = df_completed["timestamp"].max()
-    coverage_start = df_Sv["first_ping_time"].min()
-    coverage_end = df_Sv["last_ping_time"].max()
 
-    slices: list[PlannedSlice] = []
+def build_mvbs_ledger(sv_ledger: pd.DataFrame, slice_mins: int = 20) -> pd.DataFrame:
+    """Preplan every MVBS slice and its required raw files."""
+    if sv_ledger.empty:
+        return pd.DataFrame()
+
+    ledger = sv_ledger.copy()
+    ledger["timestamp"] = pd.to_datetime(ledger["timestamp"], utc=True)
+    duration = pd.Timedelta(minutes=slice_mins)
+    final_end = ledger["timestamp"].max().floor(f"{slice_mins}min") + duration
     windows = generate_aligned_windows(
-        df_Sv["first_ping_time"].min(),
-        watermark,
+        ledger["timestamp"].min(),
+        final_end,
         slice_mins,
     )
+
+    records = []
     for window in windows:
-        # Include the preceding raw file because it may cross the slice boundary
-        expected = df_raw[
-            (df_raw["timestamp"] >= window.start_time) & (df_raw["timestamp"] < window.end_time)
+        required = ledger[
+            (ledger["timestamp"] >= window.start_time) & (ledger["timestamp"] < window.end_time)
         ]
-        predecessor = df_raw[df_raw["timestamp"] < window.start_time].sort_values("timestamp").tail(1)
-        if not predecessor.empty:
-            expected = pd.concat([predecessor, expected], ignore_index=True)
-        expected_keys = set(expected["s3_path"].astype(str))
-        if expected_keys and expected_keys.issubset(completed_keys):
-            # Pass every converted Sv store that overlaps the half-open slice
-            overlapping = select_overlapping_records(
-                df_Sv,
-                window,
-                "first_ping_time",
-                "last_ping_time",
-            ).sort_values("first_ping_time")
-            if not overlapping.empty:
-                input_signature = build_input_signature(
-                    overlapping,
-                    ["Sv_filename", "first_ping_time", "last_ping_time"],
-                    window,
-                )
-                slices.append(
-                    PlannedSlice(
-                        start_time=window.start_time,
-                        end_time=window.end_time,
-                        filenames=tuple(overlapping["Sv_filename"].astype(str)),
-                        is_partial=(
-                            coverage_start > window.start_time or coverage_end < window.end_time
-                        ),
-                        input_signature=input_signature,
-                    )
-                )
+        predecessor = ledger[ledger["timestamp"] < window.start_time].tail(1)
+        required = pd.concat([predecessor, required]).drop_duplicates("s3_path")
+        records.append(
+            {
+                "MVBS_filename": f"MVBS_{window.start_time:%Y%m%dT%H%M%S}.zarr",
+                "slice_start": window.start_time,
+                "slice_end": window.end_time,
+                "raw_filenames": json.dumps(required["raw_filename"].tolist()),
+                "first_ping_time": pd.NaT,
+                "last_ping_time": pd.NaT,
+                "is_partial": pd.NA,
+                "MVBS_status": "pending",
+                "error": "",
+            }
+        )
+    return pd.DataFrame.from_records(records)
+
+
+def read_or_create_sv_ledger(path_raw_list: str, ledger_path: Path) -> pd.DataFrame:
+    """Load the Sv ledger or initialize it from the complete raw file list."""
+    if ledger_path.exists():
+        return read_manifest(
+            ledger_path,
+            SV_COLUMNS_POSTPROCESSING,
+            ["timestamp", "first_ping_time", "last_ping_time"],
+        )
+
+    ledger = build_sv_ledger(pd.read_csv(path_raw_list))
+    write_manifest(ledger, ledger_path)
+    return ledger
+
+
+def read_or_create_mvbs_ledger(
+    ledger_path: Path,
+    sv_ledger: pd.DataFrame,
+    slice_mins: int,
+) -> pd.DataFrame:
+    """Load the MVBS ledger or initialize it based on the Sv ledger."""
+    if ledger_path.exists():
+        return read_manifest(
+            ledger_path,
+            MVBS_COLUMNS_POSTPROCESSING,
+            ["slice_start", "slice_end", "first_ping_time", "last_ping_time"],
+        )
+
+    ledger = build_mvbs_ledger(sv_ledger, slice_mins)
+    write_manifest(ledger, ledger_path)
+    return ledger
+
+
+def plan_mvbs_slices(
+    sv_ledger: pd.DataFrame,
+    mvbs_ledger: pd.DataFrame,
+) -> list[PlannedSlice]:
+    """Return pending MVBS slices whose required raw conversions are complete."""
+    if sv_ledger.empty or mvbs_ledger.empty:
+        return []
+
+    df_Sv = sv_ledger.copy()
+    df_MVBS = mvbs_ledger.copy()
+
+    # Ensure datetime columns are in UTC
+    df_Sv["first_ping_time"] = pd.to_datetime(df_Sv["first_ping_time"], utc=True)
+    df_Sv["last_ping_time"] = pd.to_datetime(df_Sv["last_ping_time"], utc=True)
+    df_MVBS["slice_start"] = pd.to_datetime(df_MVBS["slice_start"], utc=True)
+    df_MVBS["slice_end"] = pd.to_datetime(df_MVBS["slice_end"], utc=True)
+
+    slices: list[PlannedSlice] = []
+    for row in df_MVBS.itertuples(index=False):
+        required_raw = json.loads(row.raw_filenames)
+        required_Sv = df_Sv[df_Sv["raw_filename"].isin(required_raw)]
+        if len(required_Sv) != len(required_raw):
+            raise ValueError(f"MVBS ledger references unknown raw files: {required_raw}")
+
+        # Skip if any required Sv conversions are not yet completed
+        if not required_Sv["raw2Sv_status"].eq("completed").all():
+            continue
+
+        window = TimeWindow(row.slice_start, row.slice_end)
+        overlapping = select_overlapping_records(
+            required_Sv,
+            window,
+            "first_ping_time",
+            "last_ping_time",
+        ).sort_values("first_ping_time")
+        if overlapping.empty:
+            continue
+        slices.append(
+            PlannedSlice(
+                start_time=window.start_time,
+                end_time=window.end_time,
+                filenames=tuple(overlapping["Sv_filename"].astype(str)),
+                is_partial=(
+                    overlapping["first_ping_time"].min() > window.start_time
+                    or overlapping["last_ping_time"].max() < window.end_time
+                ),
+            )
+        )
     return slices
 
 
@@ -199,9 +276,9 @@ def plan_prediction_slices(
     slices: list[PlannedSlice] = []
     # Derive prediction windows directly from the available ping-time coverage
     windows = generate_aligned_windows(
-        df_MVBS["first_ping_time"].min(),
-        df_MVBS["last_ping_time"].max().ceil(f"{prediction_slice_mins}min"),
-        prediction_slice_mins,
+        first_time=df_MVBS["first_ping_time"].min(),
+        last_time=df_MVBS["last_ping_time"].max().ceil(f"{prediction_slice_mins}min"),
+        window_mins=prediction_slice_mins,
     )
     for window in windows:
         # Match the real-time flow's actual ping-time overlap selection
@@ -221,22 +298,12 @@ def plan_prediction_slices(
                 .any()
             )
         if not contributing.empty and (not require_complete_window or (complete and not partial)):
-            signature_columns = ["MVBS_filename", "first_ping_time", "last_ping_time"]
-            if "input_signature" in contributing:
-                # Propagate upstream Sv changes even when MVBS ping bounds stay fixed
-                signature_columns.append("input_signature")
-            input_signature = build_input_signature(
-                contributing,
-                signature_columns,
-                window,
-            )
             slices.append(
                 PlannedSlice(
                     start_time=window.start_time,
                     end_time=window.end_time,
                     filenames=tuple(contributing["MVBS_filename"].astype(str)),
                     is_partial=not complete or bool(partial),
-                    input_signature=input_signature,
                 )
             )
     return slices

--- a/src/echodataflow/operations/operations_predict_hake.py
+++ b/src/echodataflow/operations/operations_predict_hake.py
@@ -28,7 +28,7 @@ class PredictHakeWorkItem:
 
     start_time: pd.Timestamp
     end_time: pd.Timestamp
-    mvbs_filenames: tuple[str, ...]
+    filenames_MVBS: tuple[str, ...]
     filename_postfix: str
 
 
@@ -37,9 +37,9 @@ class PredictHakeSettings:
     """Processing settings shared by a batch of prediction slices."""
 
     model: binary_hake_model
-    mvbs_directory: str
-    prediction_directory: str
-    evr_directory: str
+    directory_MVBS: str
+    directory_prediction: str
+    directory_evr: str
     temperature: float = 0.5
     softmax_threshold: float = 0.5
     max_depth: float = 590.0
@@ -76,7 +76,7 @@ def predict_hake(
 
     # Combine MVBS files into a single dataset
     ds_MVBS_combine = xr.open_mfdataset(
-        [Path(settings.mvbs_directory) / mvbsf for mvbsf in item.mvbs_filenames],
+        [Path(settings.directory_MVBS) / mvbsf for mvbsf in item.filenames_MVBS],
         parallel=True,
         coords="minimal",
         data_vars="minimal",
@@ -131,17 +131,17 @@ def predict_hake(
     softmax_filename = f"softmax_{item.filename_postfix}.zarr"
     prediction_filename = f"prediction_{item.filename_postfix}.zarr"
     da_score.chunk({"scatterer_class": -1, "ping_time": -1, "depth": -1}).to_zarr(
-        store=Path(settings.prediction_directory) / score_filename,
+        store=Path(settings.directory_prediction) / score_filename,
         mode="w",
         consolidated=True,
     )
     da_score_softmax.chunk({"scatterer_class": -1, "ping_time": -1, "depth": -1}).to_zarr(
-        store=Path(settings.prediction_directory) / softmax_filename,
+        store=Path(settings.directory_prediction) / softmax_filename,
         mode="w",
         consolidated=True,
     )
     da_predict_hake.chunk({"ping_time": -1, "depth": -1}).to_zarr(
-        store=Path(settings.prediction_directory) / prediction_filename,
+        store=Path(settings.directory_prediction) / prediction_filename,
         mode="w",
         consolidated=True,
     )
@@ -149,7 +149,7 @@ def predict_hake(
     # Save to evr
     evr_filename = f"prediction_{item.filename_postfix}.evr"
     er.write_evr(
-        Path(settings.evr_directory) / evr_filename,
+        Path(settings.directory_evr) / evr_filename,
         da_predict_hake,
         region_classification="hake",
     )

--- a/src/echodataflow/operations/operations_storage.py
+++ b/src/echodataflow/operations/operations_storage.py
@@ -1,4 +1,4 @@
-"""Operations used to simulate realtime data arrival."""
+"""Reusable operations for moving data between storage systems."""
 
 from __future__ import annotations
 
@@ -45,7 +45,7 @@ def copy_s3_file(
     local_path = Path(item.local_path)
     local_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Configure anonymous access if no S3 client is provided
+    # OSN data is public, so the default client uses unsigned requests
     if s3_client is None:
         s3_client = boto3.client(
             "s3",
@@ -53,7 +53,7 @@ def copy_s3_file(
             config=Config(signature_version=UNSIGNED),
         )
 
-    # Download file
+    # Download to the exact staging path supplied by the caller
     s3_client.download_file(
         settings.s3_bucket,
         item.s3_path,

--- a/src/echodataflow/tasks/tasks_postprocessing.py
+++ b/src/echodataflow/tasks/tasks_postprocessing.py
@@ -1,0 +1,30 @@
+"""Tasks that join reusable storage and acoustic operations."""
+
+from prefect import task
+
+from echodataflow.operations.operations_acoustics import (
+    RawToSvResult,
+    RawToSvSettings,
+    RawToSvWorkItem,
+    convert_raw_to_Sv,
+)
+from echodataflow.operations.operations_storage import (
+    S3CopySettings,
+    S3CopyWorkItem,
+    copy_s3_file,
+)
+
+
+@task(log_prints=True)
+def task_s3_raw2Sv(
+    copy_item: S3CopyWorkItem,
+    copy_settings: S3CopySettings,
+    sv_settings: RawToSvSettings,
+) -> RawToSvResult:
+    """Download one raw object and immediately convert it to Sv."""
+    # Keep staging and conversion in one task so each completed future is durable work
+    copied = copy_s3_file(copy_item, copy_settings)
+    return convert_raw_to_Sv(
+        RawToSvWorkItem(raw_path=copied.local_path),
+        sv_settings,
+    )

--- a/src/echodataflow/tasks/tasks_storage.py
+++ b/src/echodataflow/tasks/tasks_storage.py
@@ -1,8 +1,8 @@
-"""Reusable Prefect tasks for simulated data arrival."""
+"""Reusable Prefect tasks for storage operations."""
 
 from prefect import task
 
-from echodataflow.operations.operations_simulation import (
+from echodataflow.operations.operations_storage import (
     S3CopyResult,
     S3CopySettings,
     S3CopyWorkItem,

--- a/src/echodataflow/utils/manifests.py
+++ b/src/echodataflow/utils/manifests.py
@@ -110,6 +110,7 @@ def filter_time_range(
     column_end_time: str | None,
     start_time: str | None,
     end_time: str | None,
+    include_exact_start_time: bool = True,
 ) -> pd.DataFrame:
     # Treat requested ranges as half-open: [start_time, end_time)
     ordered = df.sort_values(column_start_time)
@@ -118,9 +119,13 @@ def filter_time_range(
     # When only column_start_time is provided (e.g. raw filename that only marks start time)
     if column_end_time is None:
         if start_time is not None:
-            selected = selected[selected[column_start_time] >= pd.to_datetime(start_time, utc=True)]
+            lower = pd.to_datetime(start_time, utc=True)
+            if include_exact_start_time:
+                selected = selected[selected[column_start_time] >= lower]
+            else:
+                selected = selected[selected[column_start_time] > lower]
             # Include the last file starting before the requested interval
-            prev = ordered[ordered[column_start_time] < pd.to_datetime(start_time, utc=True)].tail(1)  # noqa
+            prev = ordered[ordered[column_start_time] < lower].tail(1)
             selected = pd.concat([selected, prev]).drop_duplicates()
         if end_time is not None:
             selected = selected[selected[column_start_time] < pd.to_datetime(end_time, utc=True)]
@@ -128,7 +133,11 @@ def filter_time_range(
     # When both column_start_time and column_end_time are provided (e.g. slices that mark start and end time)
     else:
         if start_time is not None:
-            selected = selected[selected[column_end_time] >= pd.to_datetime(start_time, utc=True)]
+            lower = pd.to_datetime(start_time, utc=True)
+            if include_exact_start_time:
+                selected = selected[selected[column_end_time] >= lower]
+            else:
+                selected = selected[selected[column_end_time] > lower]
         if end_time is not None:
             selected = selected[selected[column_start_time] < pd.to_datetime(end_time, utc=True)]
 

--- a/src/echodataflow/utils/manifests.py
+++ b/src/echodataflow/utils/manifests.py
@@ -11,6 +11,22 @@ if TYPE_CHECKING:
     from echodataflow.operations.operations_postprocessing import PlannedSlice
 
 RAW_COLUMNS = ["s3_path", "timestamp", "raw_filename", "status", "error"]
+REALTIME_SV_COLUMNS = [
+    "raw_filename",
+    "Sv_filename",
+    "first_ping_time",
+    "last_ping_time",
+]
+REALTIME_MVBS_COLUMNS = ["MVBS_filename", "first_ping_time", "last_ping_time"]
+REALTIME_PREDICTION_COLUMNS = [
+    "prediction_filename_postfix",
+    "score_filename",
+    "softmax_filename",
+    "prediction_filename",
+    "evr_filename",
+    "first_ping_time",
+    "last_ping_time",
+]
 SV_COLUMNS = [
     "s3_path",
     "raw_filename",

--- a/src/echodataflow/utils/manifests.py
+++ b/src/echodataflow/utils/manifests.py
@@ -11,14 +11,14 @@ if TYPE_CHECKING:
     from echodataflow.operations.operations_postprocessing import PlannedSlice
 
 RAW_COLUMNS = ["s3_path", "timestamp", "raw_filename", "status", "error"]
-REALTIME_SV_COLUMNS = [
+SV_COLUMNS_REALTIME = [
     "raw_filename",
     "Sv_filename",
     "first_ping_time",
     "last_ping_time",
 ]
-REALTIME_MVBS_COLUMNS = ["MVBS_filename", "first_ping_time", "last_ping_time"]
-REALTIME_PREDICTION_COLUMNS = [
+MVBS_COLUMNS_REALTIME = ["MVBS_filename", "first_ping_time", "last_ping_time"]
+PREDICTION_COLUMNS_REALTIME = [
     "prediction_filename_postfix",
     "score_filename",
     "softmax_filename",
@@ -27,14 +27,14 @@ REALTIME_PREDICTION_COLUMNS = [
     "first_ping_time",
     "last_ping_time",
 ]
-SV_COLUMNS = [
+SV_COLUMNS_POSTPROCESSING = [
     "s3_path",
     "raw_filename",
     "Sv_filename",
     "first_ping_time",
     "last_ping_time",
 ]
-MVBS_COLUMNS = [
+MVBS_COLUMNS_POSTPROCESSING = [
     "MVBS_filename",
     "slice_start",
     "slice_end",
@@ -42,7 +42,7 @@ MVBS_COLUMNS = [
     "last_ping_time",
     "is_partial",
 ]
-PREDICTION_COLUMNS = [
+PREDICTION_COLUMNS_POSTPROCESSING = [
     "prediction_filename_postfix",
     "score_filename",
     "softmax_filename",
@@ -59,36 +59,36 @@ def read_manifest(path: Path, columns: list[str], date_columns: list[str]) -> pd
     # Return a schema-correct empty manifest on the first run
     if not path.exists():
         return pd.DataFrame(columns=columns)
-    frame = pd.read_csv(path, index_col=0)
+    df = pd.read_csv(path, index_col=0)
     # Add newly introduced columns while preserving older manifest files
     for column in columns:
-        if column not in frame:
-            frame[column] = pd.NA
-    frame = frame[columns]
+        if column not in df:
+            df[column] = pd.NA
+    df = df[columns]
     for column in date_columns:
-        if column in frame:
-            frame[column] = pd.to_datetime(frame[column], utc=True)
-    return frame
+        if column in df:
+            df[column] = pd.to_datetime(df[column], utc=True)
+    return df
 
 
-def write_manifest(frame: pd.DataFrame, path: Path) -> None:
+def write_manifest(df: pd.DataFrame, path: Path) -> None:
     """Replace a manifest atomically; callers must still enforce one writer."""
     path.parent.mkdir(parents=True, exist_ok=True)
     # Never expose a partially written CSV to a polling downstream flow
     temporary = path.with_suffix(path.suffix + ".tmp")
-    frame.to_csv(temporary, date_format="%Y-%m-%dT%H:%M:%S.%f%z")
+    df.to_csv(temporary, date_format="%Y-%m-%dT%H:%M:%S.%f%z")
     temporary.replace(path)
 
 
 def filter_time_range(
-    frame: pd.DataFrame,
+    df: pd.DataFrame,
     column: str,
     start_time: str | None,
     end_time: str | None,
     include_boundary_neighbors: bool = False,
 ) -> pd.DataFrame:
     # Treat requested ranges as half-open: [start_time, end_time)
-    ordered = frame.sort_values(column)
+    ordered = df.sort_values(column)
     selected = ordered
     if start_time is not None:
         selected = selected[selected[column] >= pd.to_datetime(start_time, utc=True)]

--- a/src/echodataflow/utils/manifests.py
+++ b/src/echodataflow/utils/manifests.py
@@ -77,7 +77,8 @@ def read_manifest(path: Path, columns: list[str], date_columns: list[str]) -> pd
     # Set datetime columns to UTC
     for column in date_columns:
         if column in df:
-            df[column] = pd.to_datetime(df[column], utc=True)
+            # Ledger updates can mix legacy naive values with UTC-qualified values
+            df[column] = pd.to_datetime(df[column], format="mixed", utc=True)
     return df
 
 

--- a/src/echodataflow/utils/manifests.py
+++ b/src/echodataflow/utils/manifests.py
@@ -1,0 +1,109 @@
+"""Utilities for reading, writing, and filtering processing manifests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from echodataflow.operations.operations_postprocessing import PlannedSlice
+
+RAW_COLUMNS = ["s3_path", "timestamp", "raw_filename", "status", "error"]
+SV_COLUMNS = [
+    "s3_path",
+    "raw_filename",
+    "Sv_filename",
+    "first_ping_time",
+    "last_ping_time",
+]
+MVBS_COLUMNS = [
+    "MVBS_filename",
+    "slice_start",
+    "slice_end",
+    "first_ping_time",
+    "last_ping_time",
+    "is_partial",
+]
+PREDICTION_COLUMNS = [
+    "prediction_filename_postfix",
+    "score_filename",
+    "softmax_filename",
+    "prediction_filename",
+    "evr_filename",
+    "slice_start",
+    "slice_end",
+    "first_ping_time",
+    "last_ping_time",
+]
+
+
+def read_manifest(path: Path, columns: list[str], date_columns: list[str]) -> pd.DataFrame:
+    # Return a schema-correct empty manifest on the first run
+    if not path.exists():
+        return pd.DataFrame(columns=columns)
+    frame = pd.read_csv(path, index_col=0)
+    # Add newly introduced columns while preserving older manifest files
+    for column in columns:
+        if column not in frame:
+            frame[column] = pd.NA
+    frame = frame[columns]
+    for column in date_columns:
+        if column in frame:
+            frame[column] = pd.to_datetime(frame[column], utc=True)
+    return frame
+
+
+def write_manifest(frame: pd.DataFrame, path: Path) -> None:
+    """Replace a manifest atomically; callers must still enforce one writer."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Never expose a partially written CSV to a polling downstream flow
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    frame.to_csv(temporary, date_format="%Y-%m-%dT%H:%M:%S.%f%z")
+    temporary.replace(path)
+
+
+def filter_time_range(
+    frame: pd.DataFrame,
+    column: str,
+    start_time: str | None,
+    end_time: str | None,
+    include_boundary_neighbors: bool = False,
+) -> pd.DataFrame:
+    # Treat requested ranges as half-open: [start_time, end_time)
+    ordered = frame.sort_values(column)
+    selected = ordered
+    if start_time is not None:
+        selected = selected[selected[column] >= pd.to_datetime(start_time, utc=True)]
+    if end_time is not None:
+        selected = selected[selected[column] < pd.to_datetime(end_time, utc=True)]
+
+    if include_boundary_neighbors:
+        neighbors = []
+        if start_time is not None:
+            # Include the last file starting before the requested interval
+            before = ordered[ordered[column] < pd.to_datetime(start_time, utc=True)].tail(1)
+            neighbors.append(before)
+        if end_time is not None:
+            # Include the first file starting at or after the requested interval
+            after = ordered[ordered[column] >= pd.to_datetime(end_time, utc=True)].head(1)
+            neighbors.append(after)
+        selected = pd.concat([selected, *neighbors]).drop_duplicates()
+
+    return selected.sort_values(column)
+
+
+def filter_slices(
+    slices: list[PlannedSlice],
+    start_time: str | None,
+    end_time: str | None,
+) -> list[PlannedSlice]:
+    # Require complete slice containment within optional user bounds
+    lower = pd.to_datetime(start_time, utc=True) if start_time else None
+    upper = pd.to_datetime(end_time, utc=True) if end_time else None
+    return [
+        item
+        for item in slices
+        if (lower is None or item.start_time >= lower) and (upper is None or item.end_time <= upper)
+    ]

--- a/src/echodataflow/utils/manifests.py
+++ b/src/echodataflow/utils/manifests.py
@@ -36,11 +36,10 @@ SV_COLUMNS_POSTPROCESSING = [
 ]
 MVBS_COLUMNS_POSTPROCESSING = [
     "MVBS_filename",
-    "slice_start",
-    "slice_end",
     "first_ping_time",
     "last_ping_time",
     "is_partial",
+    "input_signature",
 ]
 PREDICTION_COLUMNS_POSTPROCESSING = [
     "prediction_filename_postfix",
@@ -52,6 +51,7 @@ PREDICTION_COLUMNS_POSTPROCESSING = [
     "slice_end",
     "first_ping_time",
     "last_ping_time",
+    "input_signature",
 ]
 
 
@@ -78,6 +78,20 @@ def write_manifest(df: pd.DataFrame, path: Path) -> None:
     temporary = path.with_suffix(path.suffix + ".tmp")
     df.to_csv(temporary, date_format="%Y-%m-%dT%H:%M:%S.%f%z")
     temporary.replace(path)
+
+
+def manifest_signature_changed(
+    df: pd.DataFrame,
+    identity_column: str,
+    identity: str,
+    input_signature: str,
+) -> bool:
+    """Return whether an output is missing or its recorded inputs changed."""
+    matches = df[df[identity_column] == identity]
+    if matches.empty:
+        return True
+    stored = matches.iloc[-1]["input_signature"]
+    return pd.isna(stored) or str(stored) != input_signature
 
 
 def filter_time_range(

--- a/src/echodataflow/utils/manifests.py
+++ b/src/echodataflow/utils/manifests.py
@@ -44,14 +44,17 @@ MVBS_COLUMNS_POSTPROCESSING = [
 ]
 PREDICTION_COLUMNS_POSTPROCESSING = [
     "prediction_filename_postfix",
+    "slice_start",
+    "slice_end",
+    "MVBS_filenames",
     "score_filename",
     "softmax_filename",
     "prediction_filename",
     "evr_filename",
-    "slice_start",
-    "slice_end",
     "first_ping_time",
     "last_ping_time",
+    "prediction_status",
+    "error",
 ]
 
 

--- a/src/echodataflow/utils/manifests.py
+++ b/src/echodataflow/utils/manifests.py
@@ -3,12 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
-
 import pandas as pd
-
-if TYPE_CHECKING:
-    from echodataflow.operations.operations_postprocessing import PlannedSlice
 
 SV_COLUMNS_REALTIME = [
     "raw_filename",
@@ -122,7 +117,7 @@ def filter_time_range(
         if start_time is not None:
             selected = selected[selected[column_start_time] >= pd.to_datetime(start_time, utc=True)]
             # Include the last file starting before the requested interval
-            prev = ordered[ordered[column_start_time] < pd.to_datetime(start_time, utc=True)].tail(1)
+            prev = ordered[ordered[column_start_time] < pd.to_datetime(start_time, utc=True)].tail(1)  # noqa
             selected = pd.concat([selected, prev]).drop_duplicates()
         if end_time is not None:
             selected = selected[selected[column_start_time] < pd.to_datetime(end_time, utc=True)]
@@ -135,18 +130,3 @@ def filter_time_range(
             selected = selected[selected[column_start_time] < pd.to_datetime(end_time, utc=True)]
 
     return selected.sort_values(column_start_time)
-
-
-def filter_slices(
-    slices: list[PlannedSlice],
-    start_time: str | None,
-    end_time: str | None,
-) -> list[PlannedSlice]:
-    # Require complete slice containment within optional user bounds
-    lower = pd.to_datetime(start_time, utc=True) if start_time else None
-    upper = pd.to_datetime(end_time, utc=True) if end_time else None
-    return [
-        item
-        for item in slices
-        if (lower is None or item.start_time >= lower) and (upper is None or item.end_time <= upper)
-    ]

--- a/src/echodataflow/utils/manifests.py
+++ b/src/echodataflow/utils/manifests.py
@@ -10,7 +10,6 @@ import pandas as pd
 if TYPE_CHECKING:
     from echodataflow.operations.operations_postprocessing import PlannedSlice
 
-RAW_COLUMNS = ["s3_path", "timestamp", "raw_filename", "status", "error"]
 SV_COLUMNS_REALTIME = [
     "raw_filename",
     "Sv_filename",
@@ -29,17 +28,24 @@ PREDICTION_COLUMNS_REALTIME = [
 ]
 SV_COLUMNS_POSTPROCESSING = [
     "s3_path",
+    "timestamp",
     "raw_filename",
     "Sv_filename",
+    "raw2Sv_status",
     "first_ping_time",
     "last_ping_time",
+    "error",
 ]
 MVBS_COLUMNS_POSTPROCESSING = [
     "MVBS_filename",
+    "slice_start",
+    "slice_end",
+    "raw_filenames",
     "first_ping_time",
     "last_ping_time",
     "is_partial",
-    "input_signature",
+    "MVBS_status",
+    "error",
 ]
 PREDICTION_COLUMNS_POSTPROCESSING = [
     "prediction_filename_postfix",
@@ -51,7 +57,6 @@ PREDICTION_COLUMNS_POSTPROCESSING = [
     "slice_end",
     "first_ping_time",
     "last_ping_time",
-    "input_signature",
 ]
 
 
@@ -60,11 +65,18 @@ def read_manifest(path: Path, columns: list[str], date_columns: list[str]) -> pd
     if not path.exists():
         return pd.DataFrame(columns=columns)
     df = pd.read_csv(path, index_col=0)
-    # Add newly introduced columns while preserving older manifest files
-    for column in columns:
-        if column not in df:
-            df[column] = pd.NA
+
+    # Validation: catch missing or unexpected columns
+    missing = [column for column in columns if column not in df.columns]
+    unexpected = [column for column in df.columns if column not in columns]
+    if missing or unexpected:
+        raise ValueError(
+            f"Invalid manifest schema for {path}: "
+            f"missing columns={missing}, unexpected columns={unexpected}"
+        )
     df = df[columns]
+
+    # Set datetime columns to UTC
     for column in date_columns:
         if column in df:
             df[column] = pd.to_datetime(df[column], utc=True)
@@ -96,32 +108,33 @@ def manifest_signature_changed(
 
 def filter_time_range(
     df: pd.DataFrame,
-    column: str,
+    column_start_time: str,
+    column_end_time: str | None,
     start_time: str | None,
     end_time: str | None,
-    include_boundary_neighbors: bool = False,
 ) -> pd.DataFrame:
     # Treat requested ranges as half-open: [start_time, end_time)
-    ordered = df.sort_values(column)
-    selected = ordered
-    if start_time is not None:
-        selected = selected[selected[column] >= pd.to_datetime(start_time, utc=True)]
-    if end_time is not None:
-        selected = selected[selected[column] < pd.to_datetime(end_time, utc=True)]
+    ordered = df.sort_values(column_start_time)
+    selected = ordered.copy()
 
-    if include_boundary_neighbors:
-        neighbors = []
+    # When only column_start_time is provided (e.g. raw filename that only marks start time)
+    if column_end_time is None:
         if start_time is not None:
+            selected = selected[selected[column_start_time] >= pd.to_datetime(start_time, utc=True)]
             # Include the last file starting before the requested interval
-            before = ordered[ordered[column] < pd.to_datetime(start_time, utc=True)].tail(1)
-            neighbors.append(before)
+            prev = ordered[ordered[column_start_time] < pd.to_datetime(start_time, utc=True)].tail(1)
+            selected = pd.concat([selected, prev]).drop_duplicates()
         if end_time is not None:
-            # Include the first file starting at or after the requested interval
-            after = ordered[ordered[column] >= pd.to_datetime(end_time, utc=True)].head(1)
-            neighbors.append(after)
-        selected = pd.concat([selected, *neighbors]).drop_duplicates()
+            selected = selected[selected[column_start_time] < pd.to_datetime(end_time, utc=True)]
 
-    return selected.sort_values(column)
+    # When both column_start_time and column_end_time are provided (e.g. slices that mark start and end time)
+    else:
+        if start_time is not None:
+            selected = selected[selected[column_end_time] >= pd.to_datetime(start_time, utc=True)]
+        if end_time is not None:
+            selected = selected[selected[column_start_time] < pd.to_datetime(end_time, utc=True)]
+
+    return selected.sort_values(column_start_time)
 
 
 def filter_slices(

--- a/tests/deployment/test_deploy_cli.py
+++ b/tests/deployment/test_deploy_cli.py
@@ -2,6 +2,9 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
+
 def import_module_from_path(module_name, file_path):
     spec = importlib.util.spec_from_file_location(module_name, file_path)
     module = importlib.util.module_from_spec(spec)
@@ -12,7 +15,13 @@ def import_module_from_path(module_name, file_path):
 
 def _load_deploy_cli_module(install_prefect_stubs):
     install_prefect_stubs()
-    module_path = Path(__file__).resolve().parents[2] / "src" / "echodataflow" / "deployment" / "deploy_cli.py"
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "echodataflow"
+        / "deployment"
+        / "deploy_cli.py"
+    )
     return import_module_from_path("deploy_cli_test_mod", module_path)
 
 
@@ -35,6 +44,46 @@ def test_build_parser_run(install_prefect_stubs):
     assert args.target == "run"
     assert args.param_config == Path("config_ship.yaml")
     assert args.deploy_spec == Path("deploy_ship.yaml")
+
+
+@pytest.mark.parametrize(
+    ("flow_start_time", "expected_output"),
+    [
+        (
+            "2025-06-19T00:30:00+00:00",
+            "Time travel mode: flow start time is 2025-06-19T00:30:00+00:00\n",
+        ),
+        (None, ""),
+    ],
+)
+def test_run_from_specs_prints_time_travel_mode_only_when_configured(
+    monkeypatch,
+    install_prefect_stubs,
+    capsys,
+    flow_start_time,
+    expected_output,
+):
+    module = _load_deploy_cli_module(install_prefect_stubs=install_prefect_stubs)
+    param_path = Path("params.yaml")
+    deploy_path = Path("deploy.yaml")
+    configs = {
+        param_path: {"flows": {}},
+        deploy_path: {"flows": {}, "flow_start_time": flow_start_time},
+    }
+
+    monkeypatch.setattr(module, "load_config", configs.__getitem__)
+    monkeypatch.setattr(module, "resolve_registered_flows", lambda _config: {})
+    monkeypatch.setattr(module, "resolve_deployment_source", lambda **_kwargs: "source")
+    monkeypatch.setattr(module, "build_deploy_specs", lambda **_kwargs: [])
+    monkeypatch.setattr(module, "configure_concurrency_groups", lambda **_kwargs: None)
+    monkeypatch.setattr(module, "create_deployments", lambda **_kwargs: ([], []))
+
+    module._run_from_specs(
+        param_cfg_path=param_path,
+        deploy_cfg_path=deploy_path,
+    )
+
+    assert capsys.readouterr().out == expected_output
 
 
 def test_main_dispatches_run_args(monkeypatch, install_prefect_stubs):

--- a/tests/deployment/test_deploy_engine.py
+++ b/tests/deployment/test_deploy_engine.py
@@ -63,7 +63,7 @@ def test_local_deploy_specs_generate_current_flow_targets(install_prefect_stubs)
         "copy_raw": "flows_simulation",
         "raw2Sv": "flows_acoustics",
         "create_MVBS": "flows_acoustics",
-        "predict_hake": "flow_predict_hake",
+        "predict_hake": "flows_predict_hake",
         "file_upload_acoustics": "flows_helper",
         "file_upload_trawl": "flows_helper",
     }
@@ -107,7 +107,7 @@ def test_local_deploy_specs_generate_current_flow_targets(install_prefect_stubs)
         "copy_raw": "echodataflow/flows/flows_simulation.py:flow_copy_raw",
         "raw2Sv": "echodataflow/flows/flows_acoustics.py:flow_raw2Sv",
         "create_MVBS": "echodataflow/flows/flows_acoustics.py:flow_create_MVBS",
-        "predict_hake": "echodataflow/flows/flow_predict_hake.py:flow_predict_hake",
+        "predict_hake": "echodataflow/flows/flows_predict_hake.py:flow_predict_hake",
         "file_upload_acoustics": "echodataflow/flows/flows_helper.py:flow_file_upload",
         "file_upload_trawl": "echodataflow/flows/flows_helper.py:flow_file_upload",
     }

--- a/tests/deployment/test_deploy_engine.py
+++ b/tests/deployment/test_deploy_engine.py
@@ -143,12 +143,124 @@ def test_build_deploy_specs_passes_target_flow_parameters_directly(install_prefe
     assert specs[0].parameters == {"msg": "hello"}
 
 
+def test_build_deploy_specs_preserves_runner_and_concurrency_group(install_prefect_stubs):
+    install_prefect_stubs()
+    engine = importlib.import_module("echodataflow.deployment.deployment_engine")
+    runner_config = {
+        "type": "dask",
+        "cluster_kwargs": {
+            "n_workers": 4,
+            "threads_per_worker": 1,
+            "processes": True,
+        },
+    }
+
+    specs = engine.build_deploy_specs(
+        param_cfg={"flows": {"raw2Sv_postprocessing": {}}},
+        deploy_cfg={
+            "concurrency_groups": {"postprocessing": {"limit": 1}},
+            "flows": {
+                "raw2Sv_postprocessing": {
+                    "concurrency_group": "postprocessing",
+                    "task_runner": runner_config,
+                }
+            },
+        },
+        resolved_flows={
+            "raw2Sv_postprocessing": {
+                "flow_obj": object(),
+                "entrypoint": "echodataflow/flows/flows_acoustics.py:flow_raw2Sv_postprocessing",
+            }
+        },
+    )
+
+    assert specs[0].concurrency_group == "postprocessing"
+    assert specs[0].task_runner == runner_config
+
+
+def test_create_deployments_applies_runner_and_shared_queue(
+    install_prefect_stubs,
+):
+    install_prefect_stubs()
+    engine = importlib.import_module("echodataflow.deployment.deployment_engine")
+    calls = {}
+
+    class SourcedFlow:
+        def to_deployment(self, **kwargs):
+            calls["deployment"] = kwargs
+            return kwargs
+
+    class RegisteredFlow:
+        def from_source(self, **kwargs):
+            calls["source"] = kwargs
+            return SourcedFlow()
+
+    spec = engine.DeploymentSpec(
+        flow_key="raw2Sv_postprocessing",
+        deployment_name="raw2Sv-postprocessing",
+        flow_obj=RegisteredFlow(),
+        entrypoint="echodataflow/flows/flows_acoustics.py:flow_raw2Sv_postprocessing",
+        parameters={},
+        concurrency_group="postprocessing",
+        task_runner={"type": "dask", "cluster_kwargs": {"n_workers": 4}},
+    )
+
+    grouped, standalone = engine.create_deployments(
+        specs=[spec],
+        source="local-source",
+        default_work_pool_name="local",
+    )
+
+    assert calls["deployment"]["work_queue_name"] == "postprocessing"
+    runtime_config = calls["deployment"]["job_variables"]["env"]["ECHODATAFLOW_TASK_RUNNER"]
+    assert runtime_config == ('{"type": "dask", "cluster_kwargs": {"n_workers": 4}}')
+    assert len(grouped) == 1
+    assert standalone == []
+
+
+@pytest.mark.parametrize(
+    ("task_runner", "expected_message"),
+    [
+        ({"type": "unknown"}, "type must be 'dask'"),
+        (
+            {"type": "dask", "cluster_kwargs": {"n_workers": 0}},
+            "n_workers must be a positive integer",
+        ),
+        (
+            {"type": "dask", "cluster_kwargs": {"processes": "yes"}},
+            "processes must be a boolean",
+        ),
+    ],
+)
+def test_validate_deploy_config_rejects_invalid_task_runner(
+    install_prefect_stubs,
+    task_runner,
+    expected_message,
+):
+    install_prefect_stubs()
+    engine = importlib.import_module("echodataflow.deployment.deployment_engine")
+
+    with pytest.raises(ValueError, match=expected_message):
+        engine.validate_deploy_config({"flows": {"raw2Sv": {"task_runner": task_runner}}})
+
+
+def test_validate_deploy_config_rejects_undefined_concurrency_group(
+    install_prefect_stubs,
+):
+    install_prefect_stubs()
+    engine = importlib.import_module("echodataflow.deployment.deployment_engine")
+
+    with pytest.raises(ValueError, match="references undefined group 'missing'"):
+        engine.validate_deploy_config({"flows": {"raw2Sv": {"concurrency_group": "missing"}}})
+
+
 def test_validate_deploy_config_accepts_every_allowed_key(install_prefect_stubs):
     install_prefect_stubs()
     core = importlib.import_module("echodataflow.deployment.core")
     engine = importlib.import_module("echodataflow.deployment.deployment_engine")
 
     deploy_cfg = {
+        "concurrency_groups": {"postprocessing": {"limit": 2}},
         "flow_start_time": "2026-01-01T00:00:00+00:00",
         "default_work_pool_name": "default-pool",
         "source": {
@@ -160,12 +272,21 @@ def test_validate_deploy_config_accepts_every_allowed_key(install_prefect_stubs)
         },
         "flows": {
             "scheduled": {
+                "concurrency_group": "postprocessing",
                 "deployment_name": "scheduled-deployment",
                 "flow": "actual_flow_name",
                 "interval": 10,
                 "cron_offset": 3,
                 "inject_time_offset": True,
                 "work_pool_name": "special-pool",
+                "task_runner": {
+                    "type": "dask",
+                    "cluster_kwargs": {
+                        "n_workers": 4,
+                        "threads_per_worker": 1,
+                        "processes": True,
+                    },
+                },
             },
             "event_driven": {
                 "triggers": [
@@ -181,19 +302,30 @@ def test_validate_deploy_config_accepts_every_allowed_key(install_prefect_stubs)
     engine.validate_deploy_config(deploy_cfg)
 
     assert core.ALLOWED_DEPLOY_KEYS == {
+        "concurrency_groups",
         "flow_start_time",
         "default_work_pool_name",
         "source",
         "flows",
     }
     assert core.ALLOWED_FLOW_DEPLOY_KEYS == {
+        "concurrency_group",
         "deployment_name",
         "flow",
         "interval",
         "cron_offset",
         "triggers",
         "inject_time_offset",
+        "task_runner",
         "work_pool_name",
+    }
+    assert core.ALLOWED_CONCURRENCY_GROUP_KEYS == {"limit"}
+    assert core.ALLOWED_TASK_RUNNER_KEYS == {"type", "cluster_kwargs"}
+    assert core.ALLOWED_DASK_CLUSTER_KEYS == {
+        "memory_limit",
+        "n_workers",
+        "processes",
+        "threads_per_worker",
     }
     assert core.ALLOWED_TRIGGER_KEYS == {"expect", "resource_name"}
     assert core.ALLOWED_SOURCE_KEYS == {"mode", "git"}

--- a/tests/deployment/test_deploy_ship_cloud.py
+++ b/tests/deployment/test_deploy_ship_cloud.py
@@ -206,17 +206,21 @@ def test_deploy_cli_ship_characterization(monkeypatch, tmp_path, install_prefect
     flows_acoustics = types.ModuleType("flows_acoustics")
     flows_acoustics.flow_raw2Sv = FakeFlow("flow_raw2Sv", sink)
     flows_acoustics.flow_create_MVBS = FakeFlow("flow_create_MVBS", sink)
-    flow_predict_hake = types.ModuleType("flow_predict_hake")
-    flow_predict_hake.flow_predict_hake = FakeFlow("flow_predict_hake", sink)
+    flows_predict_hake = types.ModuleType("flows_predict_hake")
+    flows_predict_hake.flow_predict_hake = FakeFlow("flow_predict_hake", sink)
 
     flows_helper_mod = types.ModuleType("flows_helper")
     flows_helper_mod.flow_file_upload = FakeFlow("flow_file_upload", sink)
 
     monkeypatch.setitem(sys.modules, "flows_acoustics", flows_acoustics)
-    monkeypatch.setitem(sys.modules, "flow_predict_hake", flow_predict_hake)
+    monkeypatch.setitem(sys.modules, "flows_predict_hake", flows_predict_hake)
     monkeypatch.setitem(sys.modules, "flows_helper", flows_helper_mod)
     monkeypatch.setitem(sys.modules, "echodataflow.flows.flows_acoustics", flows_acoustics)
-    monkeypatch.setitem(sys.modules, "echodataflow.flows.flow_predict_hake", flow_predict_hake)
+    monkeypatch.setitem(
+        sys.modules,
+        "echodataflow.flows.flows_predict_hake",
+        flows_predict_hake,
+    )
     monkeypatch.setitem(sys.modules, "echodataflow.flows.flows_helper", flows_helper_mod)
 
     param_cfg = {
@@ -282,7 +286,7 @@ def test_deploy_cli_ship_characterization(monkeypatch, tmp_path, install_prefect
     ship_modules = {
         "raw2Sv": "flows_acoustics",
         "create_MVBS": "flows_acoustics",
-        "predict_hake": "flow_predict_hake",
+        "predict_hake": "flows_predict_hake",
         "file_upload_acoustics": "flows_helper",
         "file_upload_trawl": "flows_helper",
     }
@@ -309,7 +313,7 @@ def test_deploy_cli_ship_characterization(monkeypatch, tmp_path, install_prefect
     expected_entrypoints = {
         "raw2Sv": "echodataflow/flows/flows_acoustics.py:flow_raw2Sv",
         "create_MVBS": "echodataflow/flows/flows_acoustics.py:flow_create_MVBS",
-        "predict_hake": "echodataflow/flows/flow_predict_hake.py:flow_predict_hake",
+        "predict_hake": "echodataflow/flows/flows_predict_hake.py:flow_predict_hake",
         "file_upload": "echodataflow/flows/flows_helper.py:flow_file_upload",
     }
     actual_entrypoints = {

--- a/tests/deployment/test_flow_registry.py
+++ b/tests/deployment/test_flow_registry.py
@@ -57,7 +57,7 @@ def test_postprocessing_flows_are_registered_with_realtime_modules():
         "echodataflow/flows/flows_acoustics.py:flow_create_MVBS_postprocessing"
     )
     assert registry.FLOW_REGISTRY["predict_hake_postprocessing"].entrypoint == (
-        "echodataflow/flows/flow_predict_hake.py:flow_predict_hake_postprocessing"
+        "echodataflow/flows/flows_predict_hake.py:flow_predict_hake_postprocessing"
     )
 
 

--- a/tests/deployment/test_flow_registry.py
+++ b/tests/deployment/test_flow_registry.py
@@ -47,6 +47,20 @@ def test_flow_registry_contains_current_raw2sv_entrypoint():
     )
 
 
+def test_postprocessing_flows_are_registered_with_realtime_modules():
+    registry = importlib.import_module("echodataflow.deployment.flow_registry")
+
+    assert registry.FLOW_REGISTRY["raw2Sv_postprocessing"].entrypoint == (
+        "echodataflow/flows/flows_acoustics.py:flow_raw2Sv_postprocessing"
+    )
+    assert registry.FLOW_REGISTRY["create_MVBS_postprocessing"].entrypoint == (
+        "echodataflow/flows/flows_acoustics.py:flow_create_MVBS_postprocessing"
+    )
+    assert registry.FLOW_REGISTRY["predict_hake_postprocessing"].entrypoint == (
+        "echodataflow/flows/flow_predict_hake.py:flow_predict_hake_postprocessing"
+    )
+
+
 def test_resolve_registered_flows_defaults_to_recipe_key(
     monkeypatch,
     install_prefect_stubs,

--- a/tests/deployment/test_task_runners.py
+++ b/tests/deployment/test_task_runners.py
@@ -1,0 +1,38 @@
+import json
+
+from echodataflow.deployment.task_runners import (
+    TASK_RUNNER_ENV_VAR,
+    dask_task_runner_from_environment,
+)
+
+
+def test_dask_task_runner_uses_runtime_environment(monkeypatch):
+    monkeypatch.setenv(
+        TASK_RUNNER_ENV_VAR,
+        json.dumps(
+            {
+                "type": "dask",
+                "cluster_kwargs": {
+                    "n_workers": 4,
+                    "threads_per_worker": 1,
+                    "processes": True,
+                },
+            }
+        ),
+    )
+
+    runner = dask_task_runner_from_environment()
+
+    assert runner.cluster_kwargs == {
+        "n_workers": 4,
+        "threads_per_worker": 1,
+        "processes": True,
+    }
+
+
+def test_dask_task_runner_preserves_default_without_runtime_config(monkeypatch):
+    monkeypatch.delenv(TASK_RUNNER_ENV_VAR, raising=False)
+
+    runner = dask_task_runner_from_environment()
+
+    assert runner.cluster_kwargs == {}

--- a/tests/test_flow_copy_trawl.py
+++ b/tests/test_flow_copy_trawl.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from echodataflow.flows import flows_simulation
-from echodataflow.operations.operations_simulation import (
+from echodataflow.operations.operations_storage import (
     S3CopyResult,
     S3CopySettings,
     S3CopyWorkItem,

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -1,0 +1,53 @@
+import pandas as pd
+
+from echodataflow.utils.manifests import filter_time_range
+
+
+def test_filter_time_range_can_include_one_file_outside_each_boundary():
+    frame = pd.DataFrame(
+        {
+            "s3_path": ["before.raw", "first.raw", "last.raw", "after.raw", "later.raw"],
+            "timestamp": pd.to_datetime(
+                [
+                    "2025-06-18T23:54:00Z",
+                    "2025-06-19T00:02:00Z",
+                    "2025-06-19T01:54:00Z",
+                    "2025-06-19T02:02:00Z",
+                    "2025-06-19T02:10:00Z",
+                ]
+            ),
+        }
+    )
+
+    selected = filter_time_range(
+        frame,
+        "timestamp",
+        "2025-06-19T00:00:00Z",
+        "2025-06-19T02:00:00Z",
+        include_boundary_neighbors=True,
+    )
+
+    assert selected["s3_path"].tolist() == [
+        "before.raw",
+        "first.raw",
+        "last.raw",
+        "after.raw",
+    ]
+
+
+def test_filter_time_range_remains_half_open_without_neighbors():
+    frame = pd.DataFrame(
+        {
+            "s3_path": ["start.raw", "end.raw"],
+            "timestamp": pd.to_datetime(["2025-06-19T00:00:00Z", "2025-06-19T02:00:00Z"]),
+        }
+    )
+
+    selected = filter_time_range(
+        frame,
+        "timestamp",
+        "2025-06-19T00:00:00Z",
+        "2025-06-19T02:00:00Z",
+    )
+
+    assert selected["s3_path"].tolist() == ["start.raw"]

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -54,6 +54,30 @@ def test_manifest_round_trip_normalizes_utc(tmp_path):
     assert not Path(f"{path}.tmp").exists()
 
 
+def test_read_manifest_accepts_mixed_naive_and_utc_timestamps(tmp_path):
+    path = tmp_path / "manifest.csv"
+    pd.DataFrame(
+        {
+            "filename": ["first.zarr", "second.zarr"],
+            "first_ping_time": [
+                "2025-06-19 00:00:00",
+                "2025-06-19 00:20:00+00:00",
+            ],
+        }
+    ).to_csv(path)
+
+    manifest = read_manifest(
+        path,
+        ["filename", "first_ping_time"],
+        ["first_ping_time"],
+    )
+
+    assert manifest["first_ping_time"].tolist() == [
+        pd.Timestamp("2025-06-19T00:00:00Z"),
+        pd.Timestamp("2025-06-19T00:20:00Z"),
+    ]
+
+
 @pytest.mark.parametrize(
     ("stored_columns", "error_text"),
     [

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from echodataflow.utils.manifests import (
     filter_time_range,
@@ -23,13 +24,13 @@ def test_manifest_signature_detects_missing_and_changed_outputs():
     assert manifest_signature_changed(manifest, "filename", "missing.zarr", "current")
 
 
-def test_manifest_round_trip_repairs_schema_and_normalizes_utc(tmp_path):
+def test_manifest_round_trip_normalizes_utc(tmp_path):
     path = tmp_path / "manifest.csv"
     pd.DataFrame(
         {
             "filename": ["example.zarr"],
             "first_ping_time": ["2025-06-19T00:00:00"],
-            "legacy_column": ["ignored"],
+            "last_ping_time": ["2025-06-19T00:01:00"],
         }
     ).to_csv(path)
 
@@ -45,7 +46,7 @@ def test_manifest_round_trip_repairs_schema_and_normalizes_utc(tmp_path):
         "last_ping_time",
     ]
     assert manifest.loc[0, "first_ping_time"] == pd.Timestamp("2025-06-19T00:00:00Z")
-    assert pd.isna(manifest.loc[0, "last_ping_time"])
+    assert manifest.loc[0, "last_ping_time"] == pd.Timestamp("2025-06-19T00:01:00Z")
 
     write_manifest(manifest, path)
 
@@ -53,7 +54,25 @@ def test_manifest_round_trip_repairs_schema_and_normalizes_utc(tmp_path):
     assert not Path(f"{path}.tmp").exists()
 
 
-def test_filter_time_range_can_include_one_file_outside_each_boundary():
+@pytest.mark.parametrize(
+    ("stored_columns", "error_text"),
+    [
+        (["filename"], "missing columns=['first_ping_time']"),
+        (
+            ["filename", "first_ping_time", "legacy_column"],
+            "unexpected columns=['legacy_column']",
+        ),
+    ],
+)
+def test_read_manifest_rejects_schema_drift(tmp_path, stored_columns, error_text):
+    path = tmp_path / "manifest.csv"
+    pd.DataFrame([{column: "value" for column in stored_columns}]).to_csv(path)
+
+    with pytest.raises(ValueError, match=error_text.replace("[", r"\[").replace("]", r"\]")):
+        read_manifest(path, ["filename", "first_ping_time"], ["first_ping_time"])
+
+
+def test_filter_time_range_with_start_only_includes_preceding_file():
     frame = pd.DataFrame(
         {
             "s3_path": ["before.raw", "first.raw", "last.raw", "after.raw", "later.raw"],
@@ -72,16 +91,15 @@ def test_filter_time_range_can_include_one_file_outside_each_boundary():
     selected = filter_time_range(
         frame,
         "timestamp",
+        None,
         "2025-06-19T00:00:00Z",
         "2025-06-19T02:00:00Z",
-        include_boundary_neighbors=True,
     )
 
     assert selected["s3_path"].tolist() == [
         "before.raw",
         "first.raw",
         "last.raw",
-        "after.raw",
     ]
 
 
@@ -96,8 +114,45 @@ def test_filter_time_range_remains_half_open_without_neighbors():
     selected = filter_time_range(
         frame,
         "timestamp",
+        None,
         "2025-06-19T00:00:00Z",
         "2025-06-19T02:00:00Z",
     )
 
     assert selected["s3_path"].tolist() == ["start.raw"]
+
+
+def test_filter_time_range_with_start_and_end_selects_overlapping_records():
+    frame = pd.DataFrame(
+        {
+            "name": ["before", "crosses-start", "inside", "crosses-end", "after"],
+            "first_ping_time": pd.to_datetime(
+                [
+                    "2025-06-18T23:40:00Z",
+                    "2025-06-18T23:55:00Z",
+                    "2025-06-19T00:20:00Z",
+                    "2025-06-19T01:55:00Z",
+                    "2025-06-19T02:00:00Z",
+                ]
+            ),
+            "last_ping_time": pd.to_datetime(
+                [
+                    "2025-06-18T23:50:00Z",
+                    "2025-06-19T00:05:00Z",
+                    "2025-06-19T00:30:00Z",
+                    "2025-06-19T02:05:00Z",
+                    "2025-06-19T02:10:00Z",
+                ]
+            ),
+        }
+    )
+
+    selected = filter_time_range(
+        frame,
+        "first_ping_time",
+        "last_ping_time",
+        "2025-06-19T00:00:00Z",
+        "2025-06-19T02:00:00Z",
+    )
+
+    assert selected["name"].tolist() == ["crosses-start", "inside", "crosses-end"]

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -4,9 +4,23 @@ import pandas as pd
 
 from echodataflow.utils.manifests import (
     filter_time_range,
+    manifest_signature_changed,
     read_manifest,
     write_manifest,
 )
+
+
+def test_manifest_signature_detects_missing_and_changed_outputs():
+    manifest = pd.DataFrame(
+        {
+            "filename": ["output.zarr"],
+            "input_signature": ["current"],
+        }
+    )
+
+    assert not manifest_signature_changed(manifest, "filename", "output.zarr", "current")
+    assert manifest_signature_changed(manifest, "filename", "output.zarr", "changed")
+    assert manifest_signature_changed(manifest, "filename", "missing.zarr", "current")
 
 
 def test_manifest_round_trip_repairs_schema_and_normalizes_utc(tmp_path):

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -156,3 +156,24 @@ def test_filter_time_range_with_start_and_end_selects_overlapping_records():
     )
 
     assert selected["name"].tolist() == ["crosses-start", "inside", "crosses-end"]
+
+
+def test_filter_time_range_can_exclude_interval_ending_at_exact_start():
+    frame = pd.DataFrame(
+        {
+            "name": ["touches-start", "overlaps"],
+            "start": pd.to_datetime(["2025-06-18T23:40:00Z", "2025-06-18T23:50:00Z"]),
+            "end": pd.to_datetime(["2025-06-19T00:00:00Z", "2025-06-19T00:05:00Z"]),
+        }
+    )
+
+    selected = filter_time_range(
+        frame,
+        "start",
+        "end",
+        "2025-06-19T00:00:00Z",
+        "2025-06-19T00:40:00Z",
+        include_exact_start_time=False,
+    )
+
+    assert selected["name"].tolist() == ["overlaps"]

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -1,6 +1,42 @@
+from pathlib import Path
+
 import pandas as pd
 
-from echodataflow.utils.manifests import filter_time_range
+from echodataflow.utils.manifests import (
+    filter_time_range,
+    read_manifest,
+    write_manifest,
+)
+
+
+def test_manifest_round_trip_repairs_schema_and_normalizes_utc(tmp_path):
+    path = tmp_path / "manifest.csv"
+    pd.DataFrame(
+        {
+            "filename": ["example.zarr"],
+            "first_ping_time": ["2025-06-19T00:00:00"],
+            "legacy_column": ["ignored"],
+        }
+    ).to_csv(path)
+
+    manifest = read_manifest(
+        path,
+        ["filename", "first_ping_time", "last_ping_time"],
+        ["first_ping_time", "last_ping_time"],
+    )
+
+    assert manifest.columns.tolist() == [
+        "filename",
+        "first_ping_time",
+        "last_ping_time",
+    ]
+    assert manifest.loc[0, "first_ping_time"] == pd.Timestamp("2025-06-19T00:00:00Z")
+    assert pd.isna(manifest.loc[0, "last_ping_time"])
+
+    write_manifest(manifest, path)
+
+    assert path.exists()
+    assert not Path(f"{path}.tmp").exists()
 
 
 def test_filter_time_range_can_include_one_file_outside_each_boundary():

--- a/tests/test_operations_copy_raw.py
+++ b/tests/test_operations_copy_raw.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from echodataflow.operations.operations_simulation import (
+from echodataflow.operations.operations_storage import (
     S3CopyResult,
     S3CopySettings,
     S3CopyWorkItem,

--- a/tests/test_operations_copy_raw_to_Sv.py
+++ b/tests/test_operations_copy_raw_to_Sv.py
@@ -66,6 +66,6 @@ def test_copied_raw_file_can_be_converted_to_Sv(monkeypatch, tmp_path):
         ),
     )
 
-    assert sv_result.raw_filename == "example.raw"
-    assert sv_result.sv_filename == "example_Sv.zarr"
+    assert sv_result.filename_raw == "example.raw"
+    assert sv_result.filename_Sv == "example_Sv.zarr"
     assert (tmp_path / "Sv" / "example_Sv.zarr").is_dir()

--- a/tests/test_operations_copy_raw_to_Sv.py
+++ b/tests/test_operations_copy_raw_to_Sv.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from echodataflow.operations import operations_acoustics
-from echodataflow.operations.operations_simulation import (
+from echodataflow.operations.operations_storage import (
     S3CopySettings,
     S3CopyWorkItem,
     copy_s3_file,

--- a/tests/test_operations_create_MVBS.py
+++ b/tests/test_operations_create_MVBS.py
@@ -9,6 +9,7 @@ from echodataflow.operations import operations_acoustics
 class FakeSvDataset:
     def __init__(self):
         self.selection = None
+        self.sizes = {"ping_time": 2}
 
     def sel(self, **kwargs):
         self.selection = kwargs
@@ -92,8 +93,7 @@ def test_create_MVBS_processes_one_time_slice(monkeypatch, tmp_path):
     assert sv_dataset.selection == {
         "ping_time": slice(
             pd.Timestamp("2026-01-01T00:00:00"),
-            pd.Timestamp("2026-01-01T00:10:00")
-            - pd.to_timedelta("1nanoseconds"),
+            pd.Timestamp("2026-01-01T00:10:00") - pd.to_timedelta("1nanoseconds"),
         )
     }
     assert compute_call["ds_Sv"] is sv_dataset
@@ -109,4 +109,49 @@ def test_create_MVBS_processes_one_time_slice(monkeypatch, tmp_path):
         mvbs_filename="MVBS_20260101T000000.zarr",
         first_ping_time=pd.Timestamp("2026-01-01T00:00:05"),
         last_ping_time=pd.Timestamp("2026-01-01T00:09:55"),
+    )
+
+
+def test_create_MVBS_returns_no_data_before_computation(monkeypatch, tmp_path):
+    sv_dataset = FakeSvDataset()
+    sv_dataset.sizes = {"ping_time": 0}
+    compute_called = False
+
+    monkeypatch.setattr(
+        operations_acoustics.xr,
+        "open_mfdataset",
+        lambda *args, **kwargs: sv_dataset,
+    )
+
+    def fake_compute_MVBS(**kwargs):
+        nonlocal compute_called
+        compute_called = True
+
+    monkeypatch.setattr(
+        operations_acoustics.ep.commongrid,
+        "compute_MVBS",
+        fake_compute_MVBS,
+    )
+
+    result = operations_acoustics.create_MVBS(
+        operations_acoustics.CreateMVBSWorkItem(
+            start_time=pd.Timestamp("2026-01-01T04:20:00Z"),
+            end_time=pd.Timestamp("2026-01-01T04:40:00Z"),
+            sv_filenames=("last_daytime_Sv.zarr",),
+            mvbs_filename="MVBS_20260101T042000.zarr",
+        ),
+        operations_acoustics.CreateMVBSSettings(
+            sv_directory=str(tmp_path / "Sv"),
+            output_directory=str(tmp_path / "MVBS"),
+            range_bin="1m",
+            ping_time_bin="5s",
+        ),
+    )
+
+    assert not compute_called
+    assert result == operations_acoustics.CreateMVBSResult(
+        mvbs_filename="MVBS_20260101T042000.zarr",
+        first_ping_time=None,
+        last_ping_time=None,
+        has_data=False,
     )

--- a/tests/test_operations_postprocessing.py
+++ b/tests/test_operations_postprocessing.py
@@ -2,9 +2,72 @@ import pandas as pd
 import pytest
 
 from echodataflow.operations.operations_postprocessing import (
+    TimeWindow,
+    generate_aligned_windows,
     plan_mvbs_slices,
     plan_prediction_slices,
+    select_contained_records,
+    select_overlapping_records,
 )
+
+
+def test_generate_aligned_windows_returns_only_complete_windows():
+    assert generate_aligned_windows(
+        "2025-06-11T00:03:00Z",
+        "2025-06-11T01:01:00Z",
+        20,
+    ) == [
+        TimeWindow(
+            pd.Timestamp("2025-06-11T00:00:00Z"),
+            pd.Timestamp("2025-06-11T00:20:00Z"),
+        ),
+        TimeWindow(
+            pd.Timestamp("2025-06-11T00:20:00Z"),
+            pd.Timestamp("2025-06-11T00:40:00Z"),
+        ),
+        TimeWindow(
+            pd.Timestamp("2025-06-11T00:40:00Z"),
+            pd.Timestamp("2025-06-11T01:00:00Z"),
+        ),
+    ]
+
+
+def test_shared_record_selectors_apply_overlap_and_containment_rules():
+    records = pd.DataFrame(
+        {
+            "name": ["crosses-start", "contained", "crosses-end", "outside"],
+            "start": pd.to_datetime(
+                [
+                    "2025-06-10T23:55:00Z",
+                    "2025-06-11T00:05:00Z",
+                    "2025-06-11T00:15:00Z",
+                    "2025-06-11T00:20:00Z",
+                ]
+            ),
+            "end": pd.to_datetime(
+                [
+                    "2025-06-11T00:05:00Z",
+                    "2025-06-11T00:15:00Z",
+                    "2025-06-11T00:25:00Z",
+                    "2025-06-11T00:30:00Z",
+                ]
+            ),
+        }
+    )
+    window = TimeWindow(
+        pd.Timestamp("2025-06-11T00:00:00Z"),
+        pd.Timestamp("2025-06-11T00:20:00Z"),
+    )
+
+    overlapping = select_overlapping_records(records, window, "start", "end")
+    contained = select_contained_records(records, window, "start", "end")
+
+    assert overlapping["name"].tolist() == [
+        "crosses-start",
+        "contained",
+        "crosses-end",
+    ]
+    assert contained["name"].tolist() == ["contained"]
 
 
 def _raw_manifest(statuses=("completed", "completed", "completed", "completed")):

--- a/tests/test_operations_postprocessing.py
+++ b/tests/test_operations_postprocessing.py
@@ -6,8 +6,8 @@ import pytest
 from echodataflow.operations.operations_postprocessing import (
     TimeWindow,
     build_prediction_ledger,
-    build_mvbs_ledger,
-    build_sv_ledger,
+    build_MVBS_ledger,
+    build_Sv_ledger,
     generate_aligned_windows,
     plan_mvbs_slices,
     plan_prediction_slices,
@@ -90,7 +90,7 @@ def _sv_ledger(statuses=("completed", "completed", "completed", "completed")):
             ],
         }
     )
-    ledger = build_sv_ledger(raw)
+    ledger = build_Sv_ledger(raw)
     ledger["Sv_filename"] = ["a.zarr", "b.zarr", "c.zarr", "d.zarr"]
     ledger["raw2Sv_status"] = statuses
     ledger["first_ping_time"] = pd.to_datetime(
@@ -114,7 +114,7 @@ def _sv_ledger(statuses=("completed", "completed", "completed", "completed")):
 
 def test_ledgers_predeclare_raw_files_and_mvbs_slices():
     sv = _sv_ledger(("pending",) * 4)
-    mvbs = build_mvbs_ledger(sv, slice_mins=20)
+    mvbs = build_MVBS_ledger(sv, slice_mins=20)
 
     assert sv["raw_filename"].tolist() == [
         "IWCPS-D20250611-T000100.raw",
@@ -141,14 +141,14 @@ def test_sv_ledger_derives_timestamp_only_from_s3_path():
         }
     )
 
-    ledger = build_sv_ledger(raw)
+    ledger = build_Sv_ledger(raw)
 
     assert ledger.loc[0, "timestamp"] == pd.Timestamp("2025-06-11T00:01:00Z")
 
 
 def test_mvbs_slice_is_released_when_all_required_raw_files_complete():
     sv = _sv_ledger()
-    planned = plan_mvbs_slices(sv, build_mvbs_ledger(sv, slice_mins=20))
+    planned = plan_mvbs_slices(sv, build_MVBS_ledger(sv, slice_mins=20))
 
     assert len(planned) == 2
     assert planned[0].start_time == pd.Timestamp("2025-06-11T00:00:00Z")
@@ -160,11 +160,11 @@ def test_mvbs_slice_is_released_when_all_required_raw_files_complete():
 def test_pending_raw_input_keeps_its_mvbs_slice_closed():
     sv = _sv_ledger(("completed", "completed", "pending", "completed"))
 
-    assert plan_mvbs_slices(sv, build_mvbs_ledger(sv, slice_mins=20)) == []
+    assert plan_mvbs_slices(sv, build_MVBS_ledger(sv, slice_mins=20)) == []
 
 
 def test_empty_sv_ledger_builds_header_only_mvbs_ledger():
-    mvbs = build_mvbs_ledger(pd.DataFrame(), slice_mins=20)
+    mvbs = build_MVBS_ledger(pd.DataFrame(), slice_mins=20)
 
     assert mvbs.empty
     assert mvbs.columns.tolist() == MVBS_COLUMNS_POSTPROCESSING

--- a/tests/test_operations_postprocessing.py
+++ b/tests/test_operations_postprocessing.py
@@ -1,3 +1,5 @@
+import json
+
 import pandas as pd
 import pytest
 
@@ -234,9 +236,20 @@ def test_incomplete_prediction_uses_any_actual_ping_time_overlap_when_allowed():
     assert len(planned) == 1
     assert planned[0].filenames == ("overlapping.zarr",)
     assert planned[0].is_partial
-    assert planned[0].is_partial
 
 
-def test_prediction_length_must_align_with_mvbs_length():
-    with pytest.raises(ValueError, match="must be a multiple"):
-        build_prediction_ledger(pd.DataFrame(), 20, 30)
+def test_prediction_ledger_supports_overlapping_seven_minute_mvbs_slices():
+    starts = pd.date_range("2025-06-11T00:00:00Z", periods=6, freq="7min")
+    mvbs = pd.DataFrame(
+        {
+            "MVBS_filename": [f"slice-{index}.zarr" for index in range(6)],
+            "slice_start": starts,
+            "slice_end": starts + pd.Timedelta(minutes=7),
+        }
+    )
+
+    prediction = build_prediction_ledger(mvbs, 7, 40)
+
+    assert json.loads(prediction.loc[0, "MVBS_filenames"]) == [
+        f"slice-{index}.zarr" for index in range(6)
+    ]

--- a/tests/test_operations_postprocessing.py
+++ b/tests/test_operations_postprocessing.py
@@ -3,6 +3,8 @@ import pytest
 
 from echodataflow.operations.operations_postprocessing import (
     TimeWindow,
+    build_mvbs_ledger,
+    build_sv_ledger,
     generate_aligned_windows,
     plan_mvbs_slices,
     plan_prediction_slices,
@@ -70,110 +72,88 @@ def test_shared_record_selectors_apply_overlap_and_containment_rules():
     assert contained["name"].tolist() == ["contained"]
 
 
-def _raw_manifest(statuses=("completed", "completed", "completed", "completed")):
-    return pd.DataFrame(
+def _sv_ledger(statuses=("completed", "completed", "completed", "completed")):
+    raw = pd.DataFrame(
         {
-            "s3_path": ["a.raw", "b.raw", "c.raw", "d.raw"],
-            "timestamp": pd.to_datetime(
-                [
-                    "2025-06-11T00:01:00Z",
-                    "2025-06-11T00:07:00Z",
-                    "2025-06-11T00:14:00Z",
-                    "2025-06-11T00:21:00Z",
-                ]
-            ),
-            "status": statuses,
+            "s3_path": [
+                "survey/IWCPS-D20250611-T000100.raw",
+                "survey/IWCPS-D20250611-T000700.raw",
+                "survey/IWCPS-D20250611-T001400.raw",
+                "survey/IWCPS-D20250611-T002100.raw",
+            ],
+        }
+    )
+    ledger = build_sv_ledger(raw)
+    ledger["Sv_filename"] = ["a.zarr", "b.zarr", "c.zarr", "d.zarr"]
+    ledger["raw2Sv_status"] = statuses
+    ledger["first_ping_time"] = pd.to_datetime(
+        [
+            "2025-06-11T00:01:00Z",
+            "2025-06-11T00:07:00Z",
+            "2025-06-11T00:14:00Z",
+            "2025-06-11T00:21:00Z",
+        ]
+    )
+    ledger["last_ping_time"] = pd.to_datetime(
+        [
+            "2025-06-11T00:06:59Z",
+            "2025-06-11T00:13:59Z",
+            "2025-06-11T00:20:59Z",
+            "2025-06-11T00:27:00Z",
+        ]
+    )
+    return ledger
+
+
+def test_ledgers_predeclare_raw_files_and_mvbs_slices():
+    sv = _sv_ledger(("pending",) * 4)
+    mvbs = build_mvbs_ledger(sv, slice_mins=20)
+
+    assert sv["raw_filename"].tolist() == [
+        "IWCPS-D20250611-T000100.raw",
+        "IWCPS-D20250611-T000700.raw",
+        "IWCPS-D20250611-T001400.raw",
+        "IWCPS-D20250611-T002100.raw",
+    ]
+    assert mvbs["slice_start"].tolist() == [
+        pd.Timestamp("2025-06-11T00:00:00Z"),
+        pd.Timestamp("2025-06-11T00:20:00Z"),
+    ]
+    assert mvbs["raw_filenames"].tolist() == [
+        '["IWCPS-D20250611-T000100.raw", "IWCPS-D20250611-T000700.raw", '
+        '"IWCPS-D20250611-T001400.raw"]',
+        '["IWCPS-D20250611-T001400.raw", "IWCPS-D20250611-T002100.raw"]',
+    ]
+
+
+def test_sv_ledger_derives_timestamp_only_from_s3_path():
+    raw = pd.DataFrame(
+        {
+            "s3_path": ["survey/IWCPS-D20250611-T000100.raw"],
+            "timestamp": ["1999-01-01T00:00:00Z"],
         }
     )
 
+    ledger = build_sv_ledger(raw)
 
-def _sv_manifest():
-    return pd.DataFrame(
-        {
-            "s3_path": ["a.raw", "b.raw", "c.raw", "d.raw"],
-            "Sv_filename": ["a.zarr", "b.zarr", "c.zarr", "d.zarr"],
-            "first_ping_time": pd.to_datetime(
-                [
-                    "2025-06-11T00:01:00Z",
-                    "2025-06-11T00:07:00Z",
-                    "2025-06-11T00:14:00Z",
-                    "2025-06-11T00:21:00Z",
-                ]
-            ),
-            "last_ping_time": pd.to_datetime(
-                [
-                    "2025-06-11T00:06:59Z",
-                    "2025-06-11T00:13:59Z",
-                    "2025-06-11T00:20:59Z",
-                    "2025-06-11T00:27:00Z",
-                ]
-            ),
-        }
-    )
+    assert ledger.loc[0, "timestamp"] == pd.Timestamp("2025-06-11T00:01:00Z")
 
 
-def test_mvbs_slice_is_released_after_watermark_passes_end():
-    planned = plan_mvbs_slices(_raw_manifest(), _sv_manifest(), slice_mins=20)
+def test_mvbs_slice_is_released_when_all_required_raw_files_complete():
+    sv = _sv_ledger()
+    planned = plan_mvbs_slices(sv, build_mvbs_ledger(sv, slice_mins=20))
 
-    assert len(planned) == 1
+    assert len(planned) == 2
     assert planned[0].start_time == pd.Timestamp("2025-06-11T00:00:00Z")
     assert planned[0].end_time == pd.Timestamp("2025-06-11T00:20:00Z")
     assert planned[0].filenames == ("a.zarr", "b.zarr", "c.zarr")
     assert planned[0].is_partial
-    assert len(planned[0].input_signature) == 64
-
-
-def test_mvbs_signature_changes_when_sv_ping_bounds_change():
-    original = plan_mvbs_slices(_raw_manifest(), _sv_manifest(), slice_mins=20)[0]
-    changed_sv = _sv_manifest()
-    changed_sv.loc[0, "last_ping_time"] = pd.Timestamp("2025-06-11T00:07:01Z")
-
-    changed = plan_mvbs_slices(_raw_manifest(), changed_sv, slice_mins=20)[0]
-
-    assert changed.filenames == original.filenames
-    assert changed.input_signature != original.input_signature
-
-
-def test_mvbs_signature_changes_when_an_sv_file_is_added():
-    original = plan_mvbs_slices(_raw_manifest(), _sv_manifest(), slice_mins=20)[0]
-    changed_raw = pd.concat(
-        [
-            _raw_manifest(),
-            pd.DataFrame(
-                {
-                    "s3_path": ["late.raw"],
-                    "timestamp": pd.to_datetime(["2025-06-11T00:18:00Z"]),
-                    "status": ["completed"],
-                }
-            ),
-        ],
-        ignore_index=True,
-    )
-    changed_sv = pd.concat(
-        [
-            _sv_manifest(),
-            pd.DataFrame(
-                {
-                    "s3_path": ["late.raw"],
-                    "Sv_filename": ["late.zarr"],
-                    "first_ping_time": pd.to_datetime(["2025-06-11T00:18:00Z"]),
-                    "last_ping_time": pd.to_datetime(["2025-06-11T00:19:00Z"]),
-                }
-            ),
-        ],
-        ignore_index=True,
-    )
-
-    changed = plan_mvbs_slices(changed_raw, changed_sv, slice_mins=20)[0]
-
-    assert changed.filenames == ("a.zarr", "b.zarr", "c.zarr", "late.zarr")
-    assert changed.input_signature != original.input_signature
 
 
 def test_pending_raw_input_keeps_its_mvbs_slice_closed():
-    raw = _raw_manifest(("completed", "completed", "pending", "completed"))
+    sv = _sv_ledger(("completed", "completed", "pending", "completed"))
 
-    assert plan_mvbs_slices(raw, _sv_manifest(), slice_mins=20) == []
+    assert plan_mvbs_slices(sv, build_mvbs_ledger(sv, slice_mins=20)) == []
 
 
 def test_prediction_combines_two_aligned_mvbs_slices():
@@ -183,7 +163,6 @@ def test_prediction_combines_two_aligned_mvbs_slices():
             "first_ping_time": pd.to_datetime(["2025-06-11T00:00:05Z", "2025-06-11T00:20:05Z"]),
             "last_ping_time": pd.to_datetime(["2025-06-11T00:19:55Z", "2025-06-11T00:39:55Z"]),
             "is_partial": [False, False],
-            "input_signature": ["sv-signature-1", "sv-signature-2"],
         }
     )
 
@@ -193,42 +172,6 @@ def test_prediction_combines_two_aligned_mvbs_slices():
     assert planned[0].start_time == pd.Timestamp("2025-06-11T00:00:00Z")
     assert planned[0].end_time == pd.Timestamp("2025-06-11T00:40:00Z")
     assert planned[0].filenames == ("first.zarr", "second.zarr")
-    assert len(planned[0].input_signature) == 64
-
-
-def test_prediction_signature_changes_when_mvbs_ping_bounds_change():
-    mvbs = pd.DataFrame(
-        {
-            "MVBS_filename": ["first.zarr", "second.zarr"],
-            "first_ping_time": pd.to_datetime(["2025-06-11T00:00:05Z", "2025-06-11T00:20:05Z"]),
-            "last_ping_time": pd.to_datetime(["2025-06-11T00:19:55Z", "2025-06-11T00:39:55Z"]),
-            "is_partial": [False, False],
-        }
-    )
-    original = plan_prediction_slices(mvbs, 20, 40)[0]
-    mvbs.loc[1, "first_ping_time"] = pd.Timestamp("2025-06-11T00:20:10Z")
-
-    changed = plan_prediction_slices(mvbs, 20, 40)[0]
-
-    assert changed.input_signature != original.input_signature
-
-
-def test_prediction_signature_propagates_changed_mvbs_signature():
-    mvbs = pd.DataFrame(
-        {
-            "MVBS_filename": ["first.zarr", "second.zarr"],
-            "first_ping_time": pd.to_datetime(["2025-06-11T00:00:05Z", "2025-06-11T00:20:05Z"]),
-            "last_ping_time": pd.to_datetime(["2025-06-11T00:19:55Z", "2025-06-11T00:39:55Z"]),
-            "is_partial": [False, False],
-            "input_signature": ["original-1", "original-2"],
-        }
-    )
-    original = plan_prediction_slices(mvbs, 20, 40)[0]
-    mvbs.loc[1, "input_signature"] = "changed-2"
-
-    changed = plan_prediction_slices(mvbs, 20, 40)[0]
-
-    assert changed.input_signature != original.input_signature
 
 
 def test_prediction_requires_both_mvbs_slices_by_default():

--- a/tests/test_operations_postprocessing.py
+++ b/tests/test_operations_postprocessing.py
@@ -120,6 +120,54 @@ def test_mvbs_slice_is_released_after_watermark_passes_end():
     assert planned[0].end_time == pd.Timestamp("2025-06-11T00:20:00Z")
     assert planned[0].filenames == ("a.zarr", "b.zarr", "c.zarr")
     assert planned[0].is_partial
+    assert len(planned[0].input_signature) == 64
+
+
+def test_mvbs_signature_changes_when_sv_ping_bounds_change():
+    original = plan_mvbs_slices(_raw_manifest(), _sv_manifest(), slice_mins=20)[0]
+    changed_sv = _sv_manifest()
+    changed_sv.loc[0, "last_ping_time"] = pd.Timestamp("2025-06-11T00:07:01Z")
+
+    changed = plan_mvbs_slices(_raw_manifest(), changed_sv, slice_mins=20)[0]
+
+    assert changed.filenames == original.filenames
+    assert changed.input_signature != original.input_signature
+
+
+def test_mvbs_signature_changes_when_an_sv_file_is_added():
+    original = plan_mvbs_slices(_raw_manifest(), _sv_manifest(), slice_mins=20)[0]
+    changed_raw = pd.concat(
+        [
+            _raw_manifest(),
+            pd.DataFrame(
+                {
+                    "s3_path": ["late.raw"],
+                    "timestamp": pd.to_datetime(["2025-06-11T00:18:00Z"]),
+                    "status": ["completed"],
+                }
+            ),
+        ],
+        ignore_index=True,
+    )
+    changed_sv = pd.concat(
+        [
+            _sv_manifest(),
+            pd.DataFrame(
+                {
+                    "s3_path": ["late.raw"],
+                    "Sv_filename": ["late.zarr"],
+                    "first_ping_time": pd.to_datetime(["2025-06-11T00:18:00Z"]),
+                    "last_ping_time": pd.to_datetime(["2025-06-11T00:19:00Z"]),
+                }
+            ),
+        ],
+        ignore_index=True,
+    )
+
+    changed = plan_mvbs_slices(changed_raw, changed_sv, slice_mins=20)[0]
+
+    assert changed.filenames == ("a.zarr", "b.zarr", "c.zarr", "late.zarr")
+    assert changed.input_signature != original.input_signature
 
 
 def test_pending_raw_input_keeps_its_mvbs_slice_closed():
@@ -132,9 +180,10 @@ def test_prediction_combines_two_aligned_mvbs_slices():
     mvbs = pd.DataFrame(
         {
             "MVBS_filename": ["first.zarr", "second.zarr"],
-            "slice_start": pd.to_datetime(["2025-06-11T00:00:00Z", "2025-06-11T00:20:00Z"]),
-            "slice_end": pd.to_datetime(["2025-06-11T00:20:00Z", "2025-06-11T00:40:00Z"]),
+            "first_ping_time": pd.to_datetime(["2025-06-11T00:00:05Z", "2025-06-11T00:20:05Z"]),
+            "last_ping_time": pd.to_datetime(["2025-06-11T00:19:55Z", "2025-06-11T00:39:55Z"]),
             "is_partial": [False, False],
+            "input_signature": ["sv-signature-1", "sv-signature-2"],
         }
     )
 
@@ -144,19 +193,77 @@ def test_prediction_combines_two_aligned_mvbs_slices():
     assert planned[0].start_time == pd.Timestamp("2025-06-11T00:00:00Z")
     assert planned[0].end_time == pd.Timestamp("2025-06-11T00:40:00Z")
     assert planned[0].filenames == ("first.zarr", "second.zarr")
+    assert len(planned[0].input_signature) == 64
+
+
+def test_prediction_signature_changes_when_mvbs_ping_bounds_change():
+    mvbs = pd.DataFrame(
+        {
+            "MVBS_filename": ["first.zarr", "second.zarr"],
+            "first_ping_time": pd.to_datetime(["2025-06-11T00:00:05Z", "2025-06-11T00:20:05Z"]),
+            "last_ping_time": pd.to_datetime(["2025-06-11T00:19:55Z", "2025-06-11T00:39:55Z"]),
+            "is_partial": [False, False],
+        }
+    )
+    original = plan_prediction_slices(mvbs, 20, 40)[0]
+    mvbs.loc[1, "first_ping_time"] = pd.Timestamp("2025-06-11T00:20:10Z")
+
+    changed = plan_prediction_slices(mvbs, 20, 40)[0]
+
+    assert changed.input_signature != original.input_signature
+
+
+def test_prediction_signature_propagates_changed_mvbs_signature():
+    mvbs = pd.DataFrame(
+        {
+            "MVBS_filename": ["first.zarr", "second.zarr"],
+            "first_ping_time": pd.to_datetime(["2025-06-11T00:00:05Z", "2025-06-11T00:20:05Z"]),
+            "last_ping_time": pd.to_datetime(["2025-06-11T00:19:55Z", "2025-06-11T00:39:55Z"]),
+            "is_partial": [False, False],
+            "input_signature": ["original-1", "original-2"],
+        }
+    )
+    original = plan_prediction_slices(mvbs, 20, 40)[0]
+    mvbs.loc[1, "input_signature"] = "changed-2"
+
+    changed = plan_prediction_slices(mvbs, 20, 40)[0]
+
+    assert changed.input_signature != original.input_signature
 
 
 def test_prediction_requires_both_mvbs_slices_by_default():
     mvbs = pd.DataFrame(
         {
             "MVBS_filename": ["first.zarr"],
-            "slice_start": pd.to_datetime(["2025-06-11T00:00:00Z"]),
-            "slice_end": pd.to_datetime(["2025-06-11T00:20:00Z"]),
+            "first_ping_time": pd.to_datetime(["2025-06-11T00:00:05Z"]),
+            "last_ping_time": pd.to_datetime(["2025-06-11T00:19:55Z"]),
             "is_partial": [False],
         }
     )
 
     assert plan_prediction_slices(mvbs, 20, 40) == []
+
+
+def test_incomplete_prediction_uses_any_actual_ping_time_overlap_when_allowed():
+    mvbs = pd.DataFrame(
+        {
+            "MVBS_filename": ["overlapping.zarr", "outside.zarr"],
+            "first_ping_time": pd.to_datetime(["2025-06-11T00:05:00Z", "2025-06-11T00:40:00Z"]),
+            "last_ping_time": pd.to_datetime(["2025-06-11T00:15:00Z", "2025-06-11T00:45:00Z"]),
+            "is_partial": [True, True],
+        }
+    )
+
+    planned = plan_prediction_slices(
+        mvbs,
+        20,
+        40,
+        require_complete_window=False,
+    )
+
+    assert len(planned) == 2
+    assert planned[0].filenames == ("overlapping.zarr",)
+    assert planned[1].filenames == ("outside.zarr",)
 
 
 def test_prediction_length_must_align_with_mvbs_length():

--- a/tests/test_operations_postprocessing.py
+++ b/tests/test_operations_postprocessing.py
@@ -3,6 +3,7 @@ import pytest
 
 from echodataflow.operations.operations_postprocessing import (
     TimeWindow,
+    build_prediction_ledger,
     build_mvbs_ledger,
     build_sv_ledger,
     generate_aligned_windows,
@@ -160,13 +161,17 @@ def test_prediction_combines_two_aligned_mvbs_slices():
     mvbs = pd.DataFrame(
         {
             "MVBS_filename": ["first.zarr", "second.zarr"],
+            "slice_start": pd.to_datetime(["2025-06-11T00:00:00Z", "2025-06-11T00:20:00Z"]),
+            "slice_end": pd.to_datetime(["2025-06-11T00:20:00Z", "2025-06-11T00:40:00Z"]),
             "first_ping_time": pd.to_datetime(["2025-06-11T00:00:05Z", "2025-06-11T00:20:05Z"]),
             "last_ping_time": pd.to_datetime(["2025-06-11T00:19:55Z", "2025-06-11T00:39:55Z"]),
             "is_partial": [False, False],
+            "MVBS_status": ["completed", "completed"],
         }
     )
 
-    planned = plan_prediction_slices(mvbs, 20, 40)
+    prediction = build_prediction_ledger(mvbs, 20, 40)
+    planned = plan_prediction_slices(mvbs, prediction)
 
     assert len(planned) == 1
     assert planned[0].start_time == pd.Timestamp("2025-06-11T00:00:00Z")
@@ -174,41 +179,64 @@ def test_prediction_combines_two_aligned_mvbs_slices():
     assert planned[0].filenames == ("first.zarr", "second.zarr")
 
 
+def test_prediction_planner_skips_completed_prediction_windows():
+    mvbs = pd.DataFrame(
+        {
+            "MVBS_filename": ["first.zarr", "second.zarr"],
+            "slice_start": pd.to_datetime(["2025-06-11T00:00:00Z", "2025-06-11T00:20:00Z"]),
+            "slice_end": pd.to_datetime(["2025-06-11T00:20:00Z", "2025-06-11T00:40:00Z"]),
+            "first_ping_time": pd.to_datetime(["2025-06-11T00:00:05Z", "2025-06-11T00:20:05Z"]),
+            "last_ping_time": pd.to_datetime(["2025-06-11T00:19:55Z", "2025-06-11T00:39:55Z"]),
+            "is_partial": [False, False],
+            "MVBS_status": ["completed", "completed"],
+        }
+    )
+    prediction = build_prediction_ledger(mvbs, 20, 40)
+    prediction.loc[0, "prediction_status"] = "completed"
+
+    planned = plan_prediction_slices(mvbs, prediction)
+
+    assert planned == []
+
+
 def test_prediction_requires_both_mvbs_slices_by_default():
     mvbs = pd.DataFrame(
         {
             "MVBS_filename": ["first.zarr"],
+            "slice_start": pd.to_datetime(["2025-06-11T00:00:00Z"]),
+            "slice_end": pd.to_datetime(["2025-06-11T00:20:00Z"]),
             "first_ping_time": pd.to_datetime(["2025-06-11T00:00:05Z"]),
             "last_ping_time": pd.to_datetime(["2025-06-11T00:19:55Z"]),
             "is_partial": [False],
+            "MVBS_status": ["completed"],
         }
     )
 
-    assert plan_prediction_slices(mvbs, 20, 40) == []
+    assert build_prediction_ledger(mvbs, 20, 40).empty
 
 
 def test_incomplete_prediction_uses_any_actual_ping_time_overlap_when_allowed():
     mvbs = pd.DataFrame(
         {
             "MVBS_filename": ["overlapping.zarr", "outside.zarr"],
+            "slice_start": pd.to_datetime(["2025-06-11T00:00:00Z", "2025-06-11T00:40:00Z"]),
+            "slice_end": pd.to_datetime(["2025-06-11T00:20:00Z", "2025-06-11T01:00:00Z"]),
             "first_ping_time": pd.to_datetime(["2025-06-11T00:05:00Z", "2025-06-11T00:40:00Z"]),
             "last_ping_time": pd.to_datetime(["2025-06-11T00:15:00Z", "2025-06-11T00:45:00Z"]),
             "is_partial": [True, True],
+            "MVBS_status": ["completed", "completed"],
         }
     )
+    prediction = build_prediction_ledger(mvbs, 20, 40)
 
-    planned = plan_prediction_slices(
-        mvbs,
-        20,
-        40,
-        require_complete_window=False,
-    )
+    planned = plan_prediction_slices(mvbs, prediction)
 
-    assert len(planned) == 2
+    assert len(planned) == 1
     assert planned[0].filenames == ("overlapping.zarr",)
-    assert planned[1].filenames == ("outside.zarr",)
+    assert planned[0].is_partial
+    assert planned[0].is_partial
 
 
 def test_prediction_length_must_align_with_mvbs_length():
     with pytest.raises(ValueError, match="must be a multiple"):
-        plan_prediction_slices(pd.DataFrame(), 20, 30)
+        build_prediction_ledger(pd.DataFrame(), 20, 30)

--- a/tests/test_operations_postprocessing.py
+++ b/tests/test_operations_postprocessing.py
@@ -1,0 +1,101 @@
+import pandas as pd
+import pytest
+
+from echodataflow.operations.operations_postprocessing import (
+    plan_mvbs_slices,
+    plan_prediction_slices,
+)
+
+
+def _raw_manifest(statuses=("completed", "completed", "completed", "completed")):
+    return pd.DataFrame(
+        {
+            "s3_path": ["a.raw", "b.raw", "c.raw", "d.raw"],
+            "timestamp": pd.to_datetime(
+                [
+                    "2025-06-11T00:01:00Z",
+                    "2025-06-11T00:07:00Z",
+                    "2025-06-11T00:14:00Z",
+                    "2025-06-11T00:21:00Z",
+                ]
+            ),
+            "status": statuses,
+        }
+    )
+
+
+def _sv_manifest():
+    return pd.DataFrame(
+        {
+            "s3_path": ["a.raw", "b.raw", "c.raw", "d.raw"],
+            "Sv_filename": ["a.zarr", "b.zarr", "c.zarr", "d.zarr"],
+            "first_ping_time": pd.to_datetime(
+                [
+                    "2025-06-11T00:01:00Z",
+                    "2025-06-11T00:07:00Z",
+                    "2025-06-11T00:14:00Z",
+                    "2025-06-11T00:21:00Z",
+                ]
+            ),
+            "last_ping_time": pd.to_datetime(
+                [
+                    "2025-06-11T00:06:59Z",
+                    "2025-06-11T00:13:59Z",
+                    "2025-06-11T00:20:59Z",
+                    "2025-06-11T00:27:00Z",
+                ]
+            ),
+        }
+    )
+
+
+def test_mvbs_slice_is_released_after_watermark_passes_end():
+    planned = plan_mvbs_slices(_raw_manifest(), _sv_manifest(), slice_mins=20)
+
+    assert len(planned) == 1
+    assert planned[0].start_time == pd.Timestamp("2025-06-11T00:00:00Z")
+    assert planned[0].end_time == pd.Timestamp("2025-06-11T00:20:00Z")
+    assert planned[0].filenames == ("a.zarr", "b.zarr", "c.zarr")
+    assert planned[0].is_partial
+
+
+def test_pending_raw_input_keeps_its_mvbs_slice_closed():
+    raw = _raw_manifest(("completed", "completed", "pending", "completed"))
+
+    assert plan_mvbs_slices(raw, _sv_manifest(), slice_mins=20) == []
+
+
+def test_prediction_combines_two_aligned_mvbs_slices():
+    mvbs = pd.DataFrame(
+        {
+            "MVBS_filename": ["first.zarr", "second.zarr"],
+            "slice_start": pd.to_datetime(["2025-06-11T00:00:00Z", "2025-06-11T00:20:00Z"]),
+            "slice_end": pd.to_datetime(["2025-06-11T00:20:00Z", "2025-06-11T00:40:00Z"]),
+            "is_partial": [False, False],
+        }
+    )
+
+    planned = plan_prediction_slices(mvbs, 20, 40)
+
+    assert len(planned) == 1
+    assert planned[0].start_time == pd.Timestamp("2025-06-11T00:00:00Z")
+    assert planned[0].end_time == pd.Timestamp("2025-06-11T00:40:00Z")
+    assert planned[0].filenames == ("first.zarr", "second.zarr")
+
+
+def test_prediction_requires_both_mvbs_slices_by_default():
+    mvbs = pd.DataFrame(
+        {
+            "MVBS_filename": ["first.zarr"],
+            "slice_start": pd.to_datetime(["2025-06-11T00:00:00Z"]),
+            "slice_end": pd.to_datetime(["2025-06-11T00:20:00Z"]),
+            "is_partial": [False],
+        }
+    )
+
+    assert plan_prediction_slices(mvbs, 20, 40) == []
+
+
+def test_prediction_length_must_align_with_mvbs_length():
+    with pytest.raises(ValueError, match="must be a multiple"):
+        plan_prediction_slices(pd.DataFrame(), 20, 30)

--- a/tests/test_operations_postprocessing.py
+++ b/tests/test_operations_postprocessing.py
@@ -14,6 +14,10 @@ from echodataflow.operations.operations_postprocessing import (
     select_contained_records,
     select_overlapping_records,
 )
+from echodataflow.utils.manifests import (
+    MVBS_COLUMNS_POSTPROCESSING,
+    PREDICTION_COLUMNS_POSTPROCESSING,
+)
 
 
 def test_generate_aligned_windows_returns_only_complete_windows():
@@ -159,6 +163,13 @@ def test_pending_raw_input_keeps_its_mvbs_slice_closed():
     assert plan_mvbs_slices(sv, build_mvbs_ledger(sv, slice_mins=20)) == []
 
 
+def test_empty_sv_ledger_builds_header_only_mvbs_ledger():
+    mvbs = build_mvbs_ledger(pd.DataFrame(), slice_mins=20)
+
+    assert mvbs.empty
+    assert mvbs.columns.tolist() == MVBS_COLUMNS_POSTPROCESSING
+
+
 def test_prediction_combines_two_aligned_mvbs_slices():
     mvbs = pd.DataFrame(
         {
@@ -172,7 +183,7 @@ def test_prediction_combines_two_aligned_mvbs_slices():
         }
     )
 
-    prediction = build_prediction_ledger(mvbs, 20, 40)
+    prediction = build_prediction_ledger(mvbs, 40)
     planned = plan_prediction_slices(mvbs, prediction)
 
     assert len(planned) == 1
@@ -193,7 +204,7 @@ def test_prediction_planner_skips_completed_prediction_windows():
             "MVBS_status": ["completed", "completed"],
         }
     )
-    prediction = build_prediction_ledger(mvbs, 20, 40)
+    prediction = build_prediction_ledger(mvbs, 40)
     prediction.loc[0, "prediction_status"] = "completed"
 
     planned = plan_prediction_slices(mvbs, prediction)
@@ -214,7 +225,10 @@ def test_prediction_requires_both_mvbs_slices_by_default():
         }
     )
 
-    assert build_prediction_ledger(mvbs, 20, 40).empty
+    prediction = build_prediction_ledger(mvbs, 40)
+
+    assert prediction.empty
+    assert prediction.columns.tolist() == PREDICTION_COLUMNS_POSTPROCESSING
 
 
 def test_incomplete_prediction_uses_any_actual_ping_time_overlap_when_allowed():
@@ -229,7 +243,7 @@ def test_incomplete_prediction_uses_any_actual_ping_time_overlap_when_allowed():
             "MVBS_status": ["completed", "completed"],
         }
     )
-    prediction = build_prediction_ledger(mvbs, 20, 40)
+    prediction = build_prediction_ledger(mvbs, 40)
 
     planned = plan_prediction_slices(mvbs, prediction)
 
@@ -248,7 +262,7 @@ def test_prediction_ledger_supports_overlapping_seven_minute_mvbs_slices():
         }
     )
 
-    prediction = build_prediction_ledger(mvbs, 7, 40)
+    prediction = build_prediction_ledger(mvbs, 40)
 
     assert json.loads(prediction.loc[0, "MVBS_filenames"]) == [
         f"slice-{index}.zarr" for index in range(6)

--- a/tests/test_operations_predict_hake.py
+++ b/tests/test_operations_predict_hake.py
@@ -115,14 +115,14 @@ def test_predict_hake_result_chains_into_compute_NASC(monkeypatch, tmp_path):
         operations_predict_hake.PredictHakeWorkItem(
             start_time=pd.Timestamp("2026-01-01T00:00:00Z"),
             end_time=pd.Timestamp("2026-01-01T00:10:00Z"),
-            mvbs_filenames=("first.zarr", "second.zarr"),
+            filenames_MVBS=("first.zarr", "second.zarr"),
             filename_postfix="20260101T000000",
         ),
         operations_predict_hake.PredictHakeSettings(
             model=model,
-            mvbs_directory=str(tmp_path / "MVBS"),
-            prediction_directory=str(tmp_path / "prediction"),
-            evr_directory=str(tmp_path / "EVR"),
+            directory_MVBS=str(tmp_path / "MVBS"),
+            directory_prediction=str(tmp_path / "prediction"),
+            directory_evr=str(tmp_path / "EVR"),
             temperature=0.75,
             softmax_threshold=0.6,
             max_depth=590,

--- a/tests/test_operations_raw_to_Sv.py
+++ b/tests/test_operations_raw_to_Sv.py
@@ -49,8 +49,8 @@ def test_convert_raw_to_Sv_returns_structured_result(monkeypatch, tmp_path):
     )
 
     assert result == operations_acoustics.RawToSvResult(
-        raw_filename="example.raw",
-        sv_filename="example_Sv.zarr",
+        filename_raw="example.raw",
+        filename_Sv="example_Sv.zarr",
         first_ping_time=pd.Timestamp("2026-01-01T00:00:00"),
         last_ping_time=pd.Timestamp("2026-01-01T00:01:00"),
     )

--- a/tests/test_postprocessing_flow_validation.py
+++ b/tests/test_postprocessing_flow_validation.py
@@ -1,0 +1,47 @@
+import pytest
+
+from echodataflow.flows.flows_acoustics import (
+    flow_create_MVBS_postprocessing,
+    flow_raw2Sv_postprocessing,
+)
+from echodataflow.flows.flows_predict_hake import flow_predict_hake_postprocessing
+
+
+@pytest.mark.parametrize(
+    ("flow_function", "parameters"),
+    [
+        (
+            flow_raw2Sv_postprocessing.fn,
+            {"path_raw_list": "raw.csv", "path_main": "output"},
+        ),
+        (flow_create_MVBS_postprocessing.fn, {"path_main": "output"}),
+        (
+            flow_predict_hake_postprocessing.fn,
+            {"path_main": "output", "path_weight": "weights.ckpt"},
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ("start_time", "end_time"),
+    [
+        (None, None),
+        ("2025-06-19T00:00:00Z", None),
+        (None, "2025-06-19T01:00:00Z"),
+    ],
+)
+def test_overwrite_requires_bounded_time_range(
+    flow_function,
+    parameters,
+    start_time,
+    end_time,
+):
+    with pytest.raises(
+        ValueError,
+        match="overwrite=True requires explicit start_time and end_time",
+    ):
+        flow_function(
+            **parameters,
+            overwrite=True,
+            start_time=start_time,
+            end_time=end_time,
+        )

--- a/tests/test_postprocessing_flow_validation.py
+++ b/tests/test_postprocessing_flow_validation.py
@@ -1,46 +1,8 @@
-import pytest
-
 import echodataflow.flows.flows_acoustics as flows_acoustics
 
 from echodataflow.flows.flows_acoustics import (
     flow_create_MVBS_postprocessing,
 )
-from echodataflow.flows.flows_predict_hake import flow_predict_hake_postprocessing
-
-
-@pytest.mark.parametrize(
-    ("flow_function", "parameters"),
-    [
-        (
-            flow_predict_hake_postprocessing.fn,
-            {"path_main": "output", "path_weight": "weights.ckpt"},
-        ),
-    ],
-)
-@pytest.mark.parametrize(
-    ("start_time", "end_time"),
-    [
-        (None, None),
-        ("2025-06-19T00:00:00Z", None),
-        (None, "2025-06-19T01:00:00Z"),
-    ],
-)
-def test_overwrite_requires_bounded_time_range(
-    flow_function,
-    parameters,
-    start_time,
-    end_time,
-):
-    with pytest.raises(
-        ValueError,
-        match="overwrite=True requires explicit start_time and end_time",
-    ):
-        flow_function(
-            **parameters,
-            overwrite=True,
-            start_time=start_time,
-            end_time=end_time,
-        )
 
 
 def test_mvbs_flow_skips_when_sv_ledger_does_not_exist(tmp_path, monkeypatch):

--- a/tests/test_postprocessing_flow_validation.py
+++ b/tests/test_postprocessing_flow_validation.py
@@ -1,8 +1,10 @@
 import echodataflow.flows.flows_acoustics as flows_acoustics
+import echodataflow.flows.flows_predict_hake as flows_predict_hake
 
 from echodataflow.flows.flows_acoustics import (
     flow_create_MVBS_postprocessing,
 )
+from echodataflow.flows.flows_predict_hake import flow_predict_hake_postprocessing
 
 
 def test_mvbs_flow_skips_when_sv_ledger_does_not_exist(tmp_path, monkeypatch):
@@ -18,3 +20,21 @@ def test_mvbs_flow_skips_when_sv_ledger_does_not_exist(tmp_path, monkeypatch):
 
     assert messages == ["Sv ledger does not yet exist"]
     assert not (tmp_path / "MVBS_files.csv").exists()
+
+
+def test_prediction_flow_skips_when_mvbs_ledger_does_not_exist(tmp_path, monkeypatch):
+    messages = []
+
+    class Logger:
+        def info(self, message):
+            messages.append(message)
+
+    monkeypatch.setattr(flows_predict_hake, "get_run_logger", lambda: Logger())
+
+    flow_predict_hake_postprocessing.fn(
+        path_main=str(tmp_path),
+        path_weight="unused.ckpt",
+    )
+
+    assert messages == ["MVBS ledger does not yet exist"]
+    assert not (tmp_path / "prediction_files.csv").exists()

--- a/tests/test_postprocessing_flow_validation.py
+++ b/tests/test_postprocessing_flow_validation.py
@@ -1,8 +1,9 @@
 import pytest
 
+import echodataflow.flows.flows_acoustics as flows_acoustics
+
 from echodataflow.flows.flows_acoustics import (
     flow_create_MVBS_postprocessing,
-    flow_raw2Sv_postprocessing,
 )
 from echodataflow.flows.flows_predict_hake import flow_predict_hake_postprocessing
 
@@ -10,11 +11,6 @@ from echodataflow.flows.flows_predict_hake import flow_predict_hake_postprocessi
 @pytest.mark.parametrize(
     ("flow_function", "parameters"),
     [
-        (
-            flow_raw2Sv_postprocessing.fn,
-            {"path_raw_list": "raw.csv", "path_main": "output"},
-        ),
-        (flow_create_MVBS_postprocessing.fn, {"path_main": "output"}),
         (
             flow_predict_hake_postprocessing.fn,
             {"path_main": "output", "path_weight": "weights.ckpt"},
@@ -45,3 +41,18 @@ def test_overwrite_requires_bounded_time_range(
             start_time=start_time,
             end_time=end_time,
         )
+
+
+def test_mvbs_flow_skips_when_sv_ledger_does_not_exist(tmp_path, monkeypatch):
+    messages = []
+
+    class Logger:
+        def info(self, message):
+            messages.append(message)
+
+    monkeypatch.setattr(flows_acoustics, "get_run_logger", lambda: Logger())
+
+    flow_create_MVBS_postprocessing.fn(path_main=str(tmp_path))
+
+    assert messages == ["Sv ledger does not yet exist"]
+    assert not (tmp_path / "MVBS_files.csv").exists()

--- a/tests/test_tasks_postprocessing.py
+++ b/tests/test_tasks_postprocessing.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+from echodataflow.operations.operations_acoustics import RawToSvResult, RawToSvSettings
+from echodataflow.operations.operations_storage import S3CopySettings, S3CopyWorkItem
+from echodataflow.tasks import tasks_postprocessing
+
+
+def test_s3_raw2sv_chains_copy_into_conversion(monkeypatch):
+    copy_item = S3CopyWorkItem(
+        s3_path="survey/example.raw",
+        local_path="/staging/example.raw",
+    )
+    copy_settings = S3CopySettings(s3_bucket="source")
+    sv_settings = RawToSvSettings(output_directory="/Sv")
+    expected = RawToSvResult(
+        raw_filename="example.raw",
+        sv_filename="example_Sv.zarr",
+        first_ping_time="first",
+        last_ping_time="last",
+    )
+    calls = {}
+
+    def fake_copy(item, settings):
+        calls["copy"] = (item, settings)
+        return SimpleNamespace(local_path="/staging/example.raw")
+
+    def fake_convert(item, settings):
+        calls["convert"] = (item, settings)
+        return expected
+
+    monkeypatch.setattr(tasks_postprocessing, "copy_s3_file", fake_copy)
+    monkeypatch.setattr(tasks_postprocessing, "convert_raw_to_Sv", fake_convert)
+
+    result = tasks_postprocessing.task_s3_raw2Sv.fn(
+        copy_item,
+        copy_settings,
+        sv_settings,
+    )
+
+    assert result is expected
+    assert calls["copy"] == (copy_item, copy_settings)
+    assert calls["convert"][0].raw_path == "/staging/example.raw"
+    assert calls["convert"][1] is sv_settings

--- a/tests/test_tasks_postprocessing.py
+++ b/tests/test_tasks_postprocessing.py
@@ -13,8 +13,8 @@ def test_s3_raw2sv_chains_copy_into_conversion(monkeypatch):
     copy_settings = S3CopySettings(s3_bucket="source")
     sv_settings = RawToSvSettings(output_directory="/Sv")
     expected = RawToSvResult(
-        raw_filename="example.raw",
-        sv_filename="example_Sv.zarr",
+        filename_raw="example.raw",
+        filename_Sv="example_Sv.zarr",
         first_ping_time="first",
         last_ping_time="last",
     )


### PR DESCRIPTION
This PR adds post-processing flows for the real-time edge components. For post-processing there isn't a distinction between edge and cloud, and this is just to signal where the implementation has gotten to in this PR. I'll add the real-time cloud component in a separate PR.

This PR also adds utility functions in `utils` that are used by both the real-time and post-processing flows.

### Tasks
- [x] add and test post-processing edge flows
- [ ] ~bring real-time and post-processing edge flows to use the same set of underlying functions and dataclasses~ -- will do in a separate PR
- [x] set up configurable dask runner
- [x] set up concurrency limit
- [x] clean up some redundant variables
