### PR TITLE
fix: handle reversed ping time before creating MVBS

### DIFF
--- a/src/echodataflow/operations/operations_acoustics.py
+++ b/src/echodataflow/operations/operations_acoustics.py
@@ -41,6 +41,12 @@ class RawToSvResult:
     last_ping_time: pd.Timestamp
 
 
+def _clean_reversed_ping_time(x):
+    if ep.qc.exist_reversed_time(x, "ping_time"):
+        ep.qc.coerce_increasing_time(x)
+    return x
+
+
 def convert_raw_to_Sv(
     item: RawToSvWorkItem,
     settings: RawToSvSettings,
@@ -129,8 +135,10 @@ def create_MVBS(
         coords="minimal",
         data_vars="minimal",
         compat="override",
-        chunks={"channel": 1, "ping_time": 1000, "range_sample": -1},
         engine="zarr",  # use zarr engine for reading
+        preprocess=_clean_reversed_ping_time,
+    ).chunk(
+        chunks={"channel": 1, "ping_time": 1000, "range_sample": -1},
     ).sel(
         # slice start/end, end exclusive
         ping_time=slice(start_time, end_time - pd.to_timedelta("1nanoseconds"))

--- a/tests/test_operations_create_MVBS.py
+++ b/tests/test_operations_create_MVBS.py
@@ -8,8 +8,13 @@ from echodataflow.operations import operations_acoustics
 
 class FakeSvDataset:
     def __init__(self):
+        self.chunks = None
         self.selection = None
         self.sizes = {"ping_time": 2}
+
+    def chunk(self, chunks):
+        self.chunks = chunks
+        return self
 
     def sel(self, **kwargs):
         self.selection = kwargs
@@ -86,9 +91,14 @@ def test_create_MVBS_processes_one_time_slice(monkeypatch, tmp_path):
             "coords": "minimal",
             "data_vars": "minimal",
             "compat": "override",
-            "chunks": {"channel": 1, "ping_time": 1000, "range_sample": -1},
             "engine": "zarr",
+            "preprocess": operations_acoustics._clean_reversed_ping_time,
         },
+    }
+    assert sv_dataset.chunks == {
+        "channel": 1,
+        "ping_time": 1000,
+        "range_sample": -1,
     }
     assert sv_dataset.selection == {
         "ping_time": slice(
@@ -155,3 +165,24 @@ def test_create_MVBS_returns_no_data_before_computation(monkeypatch, tmp_path):
         last_ping_time=None,
         has_data=False,
     )
+
+
+def test_clean_reversed_ping_time_coerces_only_reversed_datasets(monkeypatch):
+    reversed_dataset = object()
+    increasing_dataset = object()
+    coerced = []
+
+    monkeypatch.setattr(
+        operations_acoustics.ep.qc,
+        "exist_reversed_time",
+        lambda dataset, coordinate: dataset is reversed_dataset and coordinate == "ping_time",
+    )
+    monkeypatch.setattr(
+        operations_acoustics.ep.qc,
+        "coerce_increasing_time",
+        lambda dataset: coerced.append(dataset),
+    )
+
+    assert operations_acoustics._clean_reversed_ping_time(reversed_dataset) is reversed_dataset
+    assert operations_acoustics._clean_reversed_ping_time(increasing_dataset) is increasing_dataset
+    assert coerced == [reversed_dataset]


### PR DESCRIPTION
Some .raw files contain reversed `ping_time` as we have observed before. This PR uses the `preprocess` capability of `xr.open_mfdataset` to correct those before creating MVBS slices.