### PR TITLE
Add simulated transect data generation flow

### DIFF
--- a/src/echodataflow/deployment/flow_registry.py
+++ b/src/echodataflow/deployment/flow_registry.py
@@ -63,6 +63,9 @@ FLOW_REGISTRY: dict[str, FlowRegistration] = {
     "copy_trawl": FlowRegistration(
         entrypoint="echodataflow/flows/flows_simulation.py:flow_copy_trawl",
     ),
+    "simulate_transects": FlowRegistration(
+        entrypoint="echodataflow/flows/flows_simulation.py:flow_simulate_transects",
+    ),
     "update_cache_MVBS": FlowRegistration(
         entrypoint="echodataflow/flows/flows_viz_cloud.py:flow_update_cache_MVBS",
     ),

--- a/src/echodataflow/flows/flows_simulation.py
+++ b/src/echodataflow/flows/flows_simulation.py
@@ -217,3 +217,156 @@ def flow_copy_trawl(
     )
     print(f"Flow complete. Downloaded {len(results)} files for trawl {trawl_num_str}.")
     return results
+
+@flow(log_prints=True)
+def flow_simulate_transects(
+    path_transect_csv: str,
+    survey_start: str,
+    transect_duration_minutes: int = 60,
+    start_transect_num: int = 1,
+    max_transects: int = 20,
+) -> None:
+    """Simulate realtime opening and closing of transects."""
+
+    path_transect = Path(path_transect_csv)
+    path_transect.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    survey_start_time = pd.to_datetime(
+        survey_start,
+        utc=True,
+    )
+
+    state = Variable.get(
+        _var_key(prefix="transect_state"),
+        default=None,
+    )
+
+    # ---------------------------------------------
+    # First run: open first transect
+    # ---------------------------------------------
+    if state is None:
+        transect_num_curr = start_transect_num
+        action = "open"
+    else:
+        transect_num_curr, action = state.split(":")
+        transect_num_curr = int(transect_num_curr)
+
+    if transect_num_curr > max_transects:
+        print("All simulated transects have been generated.")
+        return
+
+    transect_num = f"{transect_num_curr:03d}"
+
+    transect_start = (
+        survey_start_time
+        + pd.Timedelta(
+            minutes=(
+                transect_num_curr
+                - start_transect_num
+            )
+            * transect_duration_minutes
+        )
+    )
+
+    transect_end = (
+        transect_start
+        + pd.Timedelta(
+            minutes=transect_duration_minutes
+        )
+    )
+
+    if path_transect.exists():
+        df = pd.read_csv(
+            path_transect,
+            dtype={
+                "transectPart": "string",
+                "transectNumber": "string",
+                "transectStart": "string",
+                "transectEnd": "string",
+            },
+        )
+    else:
+        df = pd.DataFrame(
+            columns=[
+                "transectPart",
+                "transectNumber",
+                "transectStart",
+                "transectEnd",
+            ]
+        )
+
+    # ---------------------------------------------
+    # OPEN transect
+    # ---------------------------------------------
+    if action == "open":
+        row = pd.DataFrame(
+            [
+                {
+                    "transectPart": transect_num,
+                    "transectNumber": transect_num,
+                    "transectStart": transect_start.isoformat(),
+                    "transectEnd": pd.NA,
+                }
+            ]
+        )
+
+        df = pd.concat(
+            [df, row],
+            ignore_index=True,
+        )
+
+        df.to_csv(
+            path_transect,
+            index=False,
+        )
+
+        Variable.set(
+            _var_key(prefix="transect_state"),
+            f"{transect_num_curr}:close",
+            overwrite=True,
+        )
+
+        print(
+            f"Opened simulated transect {transect_num}: "
+            f"{transect_start}"
+        )
+
+        return
+
+    # ---------------------------------------------
+    # CLOSE transect
+    # ---------------------------------------------
+    idx = (
+        df["transectPart"]
+        == transect_num
+    )
+
+    if not idx.any():
+        raise ValueError(
+            f"Cannot close transect {transect_num}: "
+            "transect not found in CSV."
+        )
+
+    df.loc[
+        idx,
+        "transectEnd",
+    ] = transect_end.isoformat()
+
+    df.to_csv(
+        path_transect,
+        index=False,
+    )
+
+    print(
+        f"Closed simulated transect {transect_num}: "
+        f"{transect_end}"
+    )
+
+    Variable.set(
+        _var_key(prefix="transect_state"),
+        f"{transect_num_curr + 1}:open",
+        overwrite=True,
+    )

--- a/tests/test_flow_copy_raw.py
+++ b/tests/test_flow_copy_raw.py
@@ -1,0 +1,121 @@
+import datetime
+
+import pandas as pd
+
+from echodataflow.flows import flows_simulation
+from echodataflow.operations.operations_storage import (
+    S3CopyResult,
+    S3CopySettings,
+    S3CopyWorkItem,
+)
+
+
+class FakeTask:
+    def __init__(self):
+        self.calls = []
+
+    def with_options(self, **_options):
+        return self
+
+    def __call__(self, item, settings):
+        self.calls.append((item, settings))
+        return S3CopyResult(
+            s3_path=item.s3_path,
+            local_path=item.local_path,
+        )
+
+
+class FakeVariable:
+    stored = {}
+
+    @classmethod
+    def get(cls, key, default=None):
+        return cls.stored.get(key, default)
+
+    @classmethod
+    def set(cls, key, value, overwrite=False):
+        assert overwrite is True
+        cls.stored[key] = value
+
+
+class FakeDateTime(datetime.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        if tz is not None:
+            return cls(2024, 7, 7, 0, 30, tzinfo=datetime.timezone.utc)
+
+        # flow_copy_raw() calls datetime.now() without tz, so return the
+        # equivalent local time for 2024-07-07T00:30:00Z.
+        return cls(2024, 7, 6, 17, 30)
+
+
+def test_flow_copy_raw_simulates_new_file_arrivals(monkeypatch, tmp_path):
+    FakeVariable.stored = {}
+    fake_task = FakeTask()
+
+    raw_list = tmp_path / "raw_files.csv"
+    pd.DataFrame(
+        {
+            "timestamp": [
+                "2024-07-07T00:10:00Z",
+                "2024-07-07T00:20:00Z",
+                "2024-07-07T00:40:00Z",
+            ],
+            "s3_path": [
+                "survey/first.raw",
+                "survey/second.raw",
+                "survey/future.raw",
+            ],
+        }
+    ).to_csv(raw_list, index=False)
+
+    monkeypatch.setattr(flows_simulation, "Variable", FakeVariable)
+    monkeypatch.setattr(flows_simulation, "task_copy_s3_file", fake_task)
+    monkeypatch.setattr(flows_simulation.datetime, "datetime", FakeDateTime)
+
+    output_directory = tmp_path / "raw"
+
+    results = flows_simulation.flow_copy_raw.fn(
+        path_raw_list=str(raw_list),
+        path_copy=str(output_directory),
+        s3_bucket="raw-bucket",
+    )
+
+    assert fake_task.calls == [
+        (
+            S3CopyWorkItem(
+                s3_path="survey/first.raw",
+                local_path=str(output_directory / "first.raw"),
+            ),
+            S3CopySettings(
+                s3_bucket="raw-bucket",
+                endpoint_url="https://sdsc.osn.xsede.org",
+            ),
+        ),
+        (
+            S3CopyWorkItem(
+                s3_path="survey/second.raw",
+                local_path=str(output_directory / "second.raw"),
+            ),
+            S3CopySettings(
+                s3_bucket="raw-bucket",
+                endpoint_url="https://sdsc.osn.xsede.org",
+            ),
+        ),
+    ]
+
+    assert results == [
+        S3CopyResult(
+            s3_path="survey/first.raw",
+            local_path=str(output_directory / "first.raw"),
+        ),
+        S3CopyResult(
+            s3_path="survey/second.raw",
+            local_path=str(output_directory / "second.raw"),
+        ),
+    ]
+
+    assert any(
+        key.startswith("prev_start_time_")
+        for key in FakeVariable.stored
+    )

--- a/tests/test_flow_simulate_transects.py
+++ b/tests/test_flow_simulate_transects.py
@@ -1,0 +1,78 @@
+import pandas as pd
+
+from echodataflow.flows import flows_simulation
+
+
+class FakeVariable:
+    stored = {}
+
+    @classmethod
+    def get(cls, key, default=None):
+        return cls.stored.get(key, default)
+
+    @classmethod
+    def set(cls, key, value, overwrite=False):
+        assert overwrite is True
+        cls.stored[key] = value
+
+
+def test_flow_simulate_transects_opens_closes_and_advances(monkeypatch, tmp_path):
+    FakeVariable.stored = {}
+    monkeypatch.setattr(flows_simulation, "Variable", FakeVariable)
+
+    transect_csv = tmp_path / "transect_start_end_time.csv"
+
+    kwargs = {
+        "path_transect_csv": str(transect_csv),
+        "survey_start": "2024-07-07T00:00:00Z",
+        "transect_duration_minutes": 10,
+        "start_transect_num": 1,
+        "max_transects": 2,
+    }
+
+    # First run: open transect 001.
+    flows_simulation.flow_simulate_transects.fn(**kwargs)
+
+    df = pd.read_csv(transect_csv, dtype="string")
+    assert df["transectPart"].tolist() == ["001"]
+    assert pd.isna(df.loc[0, "transectEnd"])
+
+    # Second run: close transect 001.
+    flows_simulation.flow_simulate_transects.fn(**kwargs)
+
+    df = pd.read_csv(transect_csv, dtype="string")
+    assert df.loc[0, "transectEnd"] == "2024-07-07T00:10:00+00:00"
+
+    # Third run: open transect 002.
+    flows_simulation.flow_simulate_transects.fn(**kwargs)
+
+    df = pd.read_csv(transect_csv, dtype="string")
+    assert df["transectPart"].tolist() == ["001", "002"]
+    assert df.loc[1, "transectStart"] == "2024-07-07T00:10:00+00:00"
+    assert pd.isna(df.loc[1, "transectEnd"])
+
+
+def test_flow_simulate_transects_stops_after_maximum(monkeypatch, tmp_path, capsys):
+    FakeVariable.stored = {}
+    monkeypatch.setattr(flows_simulation, "Variable", FakeVariable)
+
+    transect_csv = tmp_path / "transect_start_end_time.csv"
+
+    kwargs = {
+        "path_transect_csv": str(transect_csv),
+        "survey_start": "2024-07-07T00:00:00Z",
+        "transect_duration_minutes": 10,
+        "start_transect_num": 1,
+        "max_transects": 1,
+    }
+
+    # Open 001, close 001, then attempt to advance beyond max_transects.
+    flows_simulation.flow_simulate_transects.fn(**kwargs)
+    flows_simulation.flow_simulate_transects.fn(**kwargs)
+    flows_simulation.flow_simulate_transects.fn(**kwargs)
+
+    output = capsys.readouterr().out
+    assert "All simulated transects have been generated." in output
+
+    df = pd.read_csv(transect_csv, dtype="string")
+    assert df["transectPart"].tolist() == ["001"]


### PR DESCRIPTION
we add a generic flow for simulating realtime transect start/end updates, analogous to the existing `copy_raw` and `copy_trawl` simulation flows. This is intended for testing realtime workflows that depend on transect updates, without coupling the simulation logic to a specific downstream workflow.

the simulate_transects` flow:
- progressively opens and closes transects in a transect start/end CSV
- keeps simulation state between runs using a Prefect `Variable`
- allows configuring the survey start time, transect duration, starting transect number, and maximum number of transects
- is registered so it can be referenced from deployment recipes

this PR also adds flow-level tests for:
- the existing `copy_raw` simulated raw-file stream
- the new transect simulation flow
