### PR TITLE
Refactor cloud integration flows

### DIFF
--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -212,6 +212,8 @@ def flow_raw2Sv(
                 for result in results
             ]
         )
+        for column in ["first_ping_time", "last_ping_time"]:
+            df_new[column] = pd.to_datetime(df_new[column], utc=True)
 
         # Concatenate with existing df_Sv and save
         df_Sv = pd.concat([df_Sv, df_new], ignore_index=True)
@@ -300,7 +302,8 @@ async def flow_create_MVBS(
 
     # Load Sv and MVBS info dataframes
     if not file_Sv_csv.exists():
-        raise ValueError("Sv info csv does not exist, check raw2Sv flow!")
+        logger.info("Sv info csv does not exist, check raw2Sv flow!")
+        return
     df_Sv = read_manifest(
         file_Sv_csv,
         SV_COLUMNS_REALTIME,

--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -18,6 +18,7 @@ from echodataflow.deployment.task_runners import dask_task_runner_from_environme
 from echodataflow.utils.manifests import (
     MVBS_COLUMNS_POSTPROCESSING,
     MVBS_COLUMNS_REALTIME,
+    SV_COLUMNS_REALTIME,
     SV_COLUMNS_POSTPROCESSING,
     filter_time_range,
     read_manifest,
@@ -27,6 +28,7 @@ from echodataflow.operations.operations_acoustics import (
     CreateMVBSResult,
     CreateMVBSSettings,
     CreateMVBSWorkItem,
+    RawToSvResult,
     RawToSvSettings,
     RawToSvWorkItem,
 )
@@ -48,16 +50,6 @@ from echodataflow.utils.utils import (
     extract_datetime_from_filename,
 )
 
-from echodataflow.utils.processing_ledger import (
-    get_completed_sv_files,
-    get_raw_files_to_process,
-    initialize_ledger,
-    mark_raw_completed,
-    mark_raw_failed,
-    mark_raw_processing,
-    resolve_database,
-)
-
 # Turn on verbose logging for echopype
 # otherwise all logging will be muted
 ep.utils.log.verbose()
@@ -74,10 +66,13 @@ def flow_raw2Sv(
     sonar_model: str = "EK80",
     datagram_type: str | None = None,
     nmea_sentence: str | None = None,
+    filename_pattern: str = "*.raw",
     path_main: str = "",
-    processing_db: str = "processing.db",
+    path_raw: str = "",
+    file_Sv_csv: str = "Sv_files.csv",
     new_file_num_limit: int = 50,
 ):
+
     # Check if the deployment is already running
     already_running = asyncio.run(deployment_already_running())
     if already_running:
@@ -86,58 +81,83 @@ def flow_raw2Sv(
             async with get_client() as client:
                 await client.set_flow_run_state(
                     flow_run_id=runtime.flow_run.id,
-                    state=Cancelled(
-                        message="Another instance of this flow is already running"
-                    ),
+                    state=Cancelled(message="Another instance of this flow is already running"),
                 )
 
         asyncio.run(cancel_run())
-        return
+        return  # exit the flow early
 
     # Assemble paths
     path_Sv_zarr = Path(path_main) / "Sv"
-    db_path = resolve_database(path_main, processing_db)
-
-    initialize_ledger(db_path)
+    file_Sv_csv = Path(path_main) / file_Sv_csv
+    path_raw = Path(path_raw)
 
     # Set up folder to store converted Sv zarr
-    path_Sv_zarr.mkdir(parents=True, exist_ok=True)
+    if not path_Sv_zarr.exists():
+        path_Sv_zarr.mkdir(parents=True, exist_ok=True)
+    path_Sv_zarr = str(path_Sv_zarr)  # convert backto string to pass into task
 
-    # Get RAW files requiring processing directly from the database
-    raw_files = get_raw_files_to_process(
-        db_path,
-        limit=new_file_num_limit,
+    # Load info dataframe containing raw to Sv correspondence
+    sv_manifest_exists = file_Sv_csv.exists()
+    df_Sv = read_manifest(
+        file_Sv_csv,
+        SV_COLUMNS_REALTIME,
+        ["first_ping_time", "last_ping_time"],
     )
+    if not sv_manifest_exists:
+        write_manifest(df_Sv, file_Sv_csv)
+    if not df_Sv.empty:
+        df_Sv.sort_values(by="first_ping_time", inplace=True, ignore_index=True)
 
-    # Exclude files before requested datetime
-    if exclude_before is not None:
-        exclude_before_dt = datetime.datetime.fromisoformat(exclude_before)
-        raw_files = [
-            raw_path
-            for raw_path in raw_files
-            if extract_datetime_from_filename(raw_path.name) >= exclude_before_dt
-        ]
+    # Exclude raw files before exclude_before datetime
+    if exclude_before is None:
+        raw_files_in_folder = set([filename.name for filename in path_raw.glob(filename_pattern)])
+    else:
+        raw_files_in_folder = set(
+            [
+                filename.name
+                for filename in path_raw.glob(filename_pattern)
+                if extract_datetime_from_filename(filename.name)
+                >= datetime.datetime.fromisoformat(exclude_before)
+            ]
+        )
 
-    # Skip explicitly excluded RAW files
-    if exclude_raw_file:
-        excluded = set(exclude_raw_file)
-        raw_files = [
-            raw_path
-            for raw_path in raw_files
-            if raw_path.name not in excluded
-        ]
+    if df_Sv.empty:
+        raw_files_in_df = set()
+    else:
+        raw_files_in_df = set(df_Sv["raw_filename"].tolist())
+    last_raw_filename = df_Sv.iloc[-1]["raw_filename"] if not df_Sv.empty else None
+    if last_raw_filename:
+        df_Sv = df_Sv[:-1]  # drop the most recent file processed
 
-    print(f"Found {len(raw_files)} RAW files to process")
-    print(
-        "Files to process:\n"
-        + "".join(f"- {raw_path.name}\n" for raw_path in raw_files)
-    )
+    # Find new files to process
+    new_files = raw_files_in_folder.difference(raw_files_in_df)
+    print(f"Found {len(new_files)} new files to process")
 
-    if not raw_files:
-        return
+    # Reprocess last file in case it was incomplete
+    if last_raw_filename:
+        print(f"Reprocess {last_raw_filename}")
+        new_files.add(last_raw_filename)
+
+    # Skip files in exclude_raw_file list
+    if len(exclude_raw_file) > 0:
+        print(f"Exclude {exclude_raw_file} from processing")
+        new_files.difference_update(set(exclude_raw_file))
+
+    # Sort new files
+    new_files = sorted(list(new_files))
+
+    # Limit number of new files to process
+    if new_file_num_limit != -1 and len(new_files) > new_file_num_limit:
+        print(
+            f"More than {new_file_num_limit} new files to process. "
+            f"Limiting to first {new_file_num_limit} files."
+        )
+        new_files = new_files[:new_file_num_limit]
+    print(f"Files to process: \n" + "".join([f"- {nf}\n" for nf in new_files]))
 
     settings = RawToSvSettings(
-        output_directory=str(path_Sv_zarr),
+        output_directory=path_Sv_zarr,
         encode_mode=encode_mode,
         waveform_mode=waveform_mode,
         depth_offset=depth_offset,
@@ -145,105 +165,74 @@ def flow_raw2Sv(
         datagram_type=datagram_type,
         nmea_sentence=nmea_sentence,
     )
-
     errors = []
+    results: list[RawToSvResult] = []
 
     if parallel:
+        # Convert raw files to Sv in parallel
         print("Processing raw files in parallel")
-
-        futures = {}
-
-        for raw_path in raw_files:
-            mark_raw_processing(db_path, raw_path)
-
-            future = task_raw2Sv.with_options(
-                task_run_name=raw_path.name,
-                name=raw_path.name,
-                retries=3,
-            ).submit(
-                RawToSvWorkItem(raw_path=str(raw_path)),
+        future_all = []
+        for nf in new_files:
+            new_processed_raw = task_raw2Sv.with_options(task_run_name=nf, name=nf, retries=3)
+            future = new_processed_raw.submit(
+                RawToSvWorkItem(raw_path=str(path_raw / nf)),
                 settings,
             )
+            future_all.append(future)
 
-            futures[future] = raw_path
-
-        for future in as_completed(futures):
-            raw_path = futures[future]
-
-            try:
-                result = future.result()
-
-                mark_raw_completed(
-                    db_path,
-                    raw_path,
-                    result.filename_Sv,
-                    result.first_ping_time,
-                    result.last_ping_time,
-                )
-
-            except Exception as exc:
-                mark_raw_failed(
-                    db_path,
-                    raw_path,
-                    str(exc),
-                )
-                errors.append(exc)
-                print(f"Error converting {raw_path.name}: {exc}")
+        for ff in future_all:
+            task_result = ff.result()
+            results.append(task_result)
 
     else:
+        # Convert raw files to Sv sequentially
         print("Processing raw files sequentially")
-
-        for raw_path in raw_files:
+        for nf in new_files:
             try:
-                print(f"Converting {raw_path.name}")
-
-                mark_raw_processing(
-                    db_path,
-                    raw_path,
-                )
-
-                result = task_raw2Sv.with_options(
-                    task_run_name=raw_path.name,
-                    name=raw_path.name,
-                    retries=3,
-                )(
-                    RawToSvWorkItem(raw_path=str(raw_path)),
+                print(f"Converting {nf}")
+                task_result = task_raw2Sv.with_options(task_run_name=nf, name=nf, retries=3)(
+                    RawToSvWorkItem(raw_path=str(path_raw / nf)),
                     settings,
                 )
+                results.append(task_result)
+            except Exception as e:
+                errors.append(e)
+                print(f"Error converting {nf}: {e}")
 
-                mark_raw_completed(
-                    db_path,
-                    raw_path,
-                    result.filename_Sv,
-                    result.first_ping_time,
-                    result.last_ping_time,
-                )
+    # Add new entries to df_Sv
+    if len(results) > 0:
+        df_new = pd.DataFrame(
+            [
+                {
+                    "raw_filename": result.filename_raw,
+                    "Sv_filename": result.filename_Sv,
+                    "first_ping_time": result.first_ping_time,
+                    "last_ping_time": result.last_ping_time,
+                }
+                for result in results
+            ]
+        )
 
-            except Exception as exc:
-                mark_raw_failed(
-                    db_path,
-                    raw_path,
-                    str(exc),
-                )
-                errors.append(exc)
-                print(f"Error converting {raw_path.name}: {exc}")
+        # Concatenate with existing df_Sv and save
+        df_Sv = pd.concat([df_Sv, df_new], ignore_index=True)
+        df_Sv.sort_values(by=["first_ping_time"], inplace=True, ignore_index=True)
+        write_manifest(df_Sv, file_Sv_csv)
+        print(f"Added {len(new_files)} new entries to tracking CSV")
 
-    # Set flow to Failed state if any conversions failed
-    if errors:
+    # Set flow to Failed state if any errors occurred
+    if len(errors) > 0:
         error_msg = (
-            f"{len(errors)} errors during raw to Sv conversion "
-            f"out of {len(raw_files)} files"
+            f"{len(errors)} errors during raw to Sv conversion out of {len(new_files)} files"
         )
 
         async def set_failed_state():
             async with get_client() as client:
                 await client.set_flow_run_state(
-                    flow_run_id=runtime.flow_run.id,
-                    state=Failed(message=error_msg),
+                    flow_run_id=runtime.flow_run.id, state=Failed(message=error_msg)
                 )
 
         asyncio.run(set_failed_state())
-        raise RuntimeError(error_msg)
+        raise Exception(error_msg)
 
 
 @flow(log_prints=True)
@@ -254,7 +243,7 @@ async def flow_create_MVBS(
     range_bin: str = "1m",
     ping_time_bin: str = "5s",
     path_main: str = "",
-    processing_db: str = "processing.db",
+    file_Sv_csv: str = "Sv_files.csv",
     file_MVBS_csv: str = "MVBS_files.csv",
 ):
     """
@@ -292,7 +281,7 @@ async def flow_create_MVBS(
     )
 
     # Assemble paths
-    db_path = resolve_database(path_main, processing_db)
+    file_Sv_csv = Path(path_main) / file_Sv_csv
     file_MVBS_csv = Path(path_main) / file_MVBS_csv
     path_Sv_zarr = Path(path_main) / "Sv"
     path_MVBS_zarr = Path(path_main) / "MVBS"
@@ -310,6 +299,19 @@ async def flow_create_MVBS(
     path_MVBS_zarr = str(path_MVBS_zarr)  # convert back to string to pass into task
 
     # Load Sv and MVBS info dataframes
+    if not file_Sv_csv.exists():
+        raise ValueError("Sv info csv does not exist, check raw2Sv flow!")
+    df_Sv = read_manifest(
+        file_Sv_csv,
+        SV_COLUMNS_REALTIME,
+        ["first_ping_time", "last_ping_time"],
+    )
+    if df_Sv.empty:
+        logger.info(
+            "Sv info csv is empty, raw2Sv flow may have just started! "
+            "No MVBS can be created, exiting flow."
+        )
+        return
 
     mvbs_manifest_exists = file_MVBS_csv.exists()
     df_MVBS = read_manifest(
@@ -334,10 +336,11 @@ async def flow_create_MVBS(
         logger.info(f"Slice {snum+1}: {start_time[snum]} to {end_time[snum]}")
 
         # Get Sv files in the specified time range
-        Sv_filenames = get_completed_sv_files(
-            db_path,
-            start_time=start_time[snum],
-            end_time=end_time[snum],
+        Sv_filenames = sorted(
+            df_Sv[
+                (pd.to_datetime(df_Sv["last_ping_time"]) >= start_time[snum])
+                & (pd.to_datetime(df_Sv["first_ping_time"]) <= end_time[snum])
+            ]["Sv_filename"].tolist()
         )
         logger.info(
             f"Found {len(Sv_filenames)} Sv files in the specified time range: \n"

--- a/src/echodataflow/flows/flows_biology.py
+++ b/src/echodataflow/flows/flows_biology.py
@@ -1,192 +1,24 @@
-import re
 from pathlib import Path
-import numpy as np
 import pandas as pd
 
 import configparser, s3fs
 
-from echodataflow.utils.const import TS_L_PARAMS, INFO_DATAFRAME_MAPPING
+from echodataflow.operations.operations_biology import (
+    add_stratum,
+    get_count_from_length_specimen,
+    get_length_weight_regression,
+    get_sigma_bs_mean_stratum,
+    get_weight_mean_stratum,
+)
+from echodataflow.utils.const import INFO_DATAFRAME_MAPPING
+from echodataflow.utils.trawl_files import get_valid_hauls
 
-from prefect import task, flow
-
-
-# Set up paths
-data_path = "/Users/feresa/code_git/echodataflow/temp_bio"
-# csv_path = data_path / "bio_csv"
-
-# # Initialize dataframes
-# df_haul_info_all = pd.DataFrame(
-#     columns=["operation_number", "timestamp", "latitude", "longitude"]
-# )
-# df_specimen_all = pd.DataFrame(
-#     columns=["operation_number", "partition", "species", "sex", "rounded_length", "frequency"]
-# )
-# df_length_all = pd.DataFrame(
-#     columns=[
-#         "operation_number", "partition", "species",
-#         "length_type", "length", "sex", "organism_weight", "barcode"
-#     ]
-# )
-# df_length_count_all = pd.DataFrame(
-#     columns=["sex", "rounded_length", "frequency", "operation_number"]
-# )
-# df_haul_info_all.to_csv(data_path / "haul_info_all.csv")
-# df_specimen_all.to_csv(data_path / "specimen_all.csv")
-# df_length_all.to_csv(data_path / "length_all.csv")
-# df_length_count_all.to_csv(data_path / "length_count_all.csv")
-
-
-
-def get_valid_hauls(
-    bio_filenames: dict,
-):
-    # Pull out haul numbers
-    HAUL_NUM_PATTERN = rf"(\w+)?(?P<haul_num>\d{{3}})_\w+\.xlsx"
-    haul_num_all = {k: set() for k in bio_filenames.keys()}
-    for file_type in bio_filenames.keys():
-        for fname in bio_filenames[file_type]:
-            match_str = re.match(HAUL_NUM_PATTERN, Path(fname).name)
-            if match_str is not None:
-                haul_num_all[file_type].add(int(match_str["haul_num"]))
-
-    # Each haul number should have 4 files as defined above
-    valid_hauls = set.union(*haul_num_all.values())
-    haul_num_to_remove = set()
-    for file_type in bio_filenames.keys():
-        haul_num_diff = valid_hauls.difference(haul_num_all[file_type])
-        if haul_num_diff:
-            haul_num_to_remove.update(haul_num_diff)
-    valid_hauls.difference_update(haul_num_to_remove)
-    return valid_hauls
-
-
-def get_count_from_length_specimen(
-    df_length: pd.DataFrame,
-    df_specimen: pd.DataFrame,
-) -> pd.DataFrame:
-    """
-    Get length count from length and specimen dataframes.
-    """
-    # Round fish length to nearest integer
-    df_specimen["length"] = df_specimen["fork_length"].round(0).astype(int)                
-
-    # Get length count from both dataframes
-    specimen_counts = (
-        df_specimen.groupby(["sex", "length", "haul"]).size()
-        .reset_index(name="frequency")
-    )
-    length_counts = (
-        df_length.groupby(["sex", "length", "haul"])
-        .agg({"frequency": "sum"}).reset_index()
-    )
-    
-    df_combined = pd.merge(
-        specimen_counts.reset_index(),
-        length_counts.reset_index(),
-        on=["sex", "length", "haul"],
-        how="outer"
-    ).fillna(0)
-    df_combined["frequency"] = (df_combined["frequency_x"] + df_combined["frequency_y"]).astype(int)
-
-    return df_combined[["sex", "length", "frequency", "haul"]]
-
-
-def get_length_weight_regression(df_specimen: pd.DataFrame) -> pd.DataFrame:
-    """
-    Get length-weight regression coefficients for male, female, and all fish combined.
-    """
-    # Male, female separately
-    df_regres = df_specimen.groupby(["sex", "stratum"]).apply(
-        lambda df: pd.Series(
-            np.polyfit(np.log10(df["length"]), np.log10(df["organism_weight"]), 1),
-            index=["p1", "p2"],
-        ),
-        include_groups = False
-    ).reset_index()
-
-    # All fish combined
-    df_all = df_specimen.groupby("stratum").apply(
-        lambda df: pd.Series(
-            np.polyfit(np.log10(df["length"]),
-                    np.log10(df["organism_weight"]), 1),
-            index=["p1", "p2"],
-        ),
-        include_groups = False
-    ).reset_index()
-    df_all["sex"] = "all"
-
-    # Combine all and make everything lowercase
-    df_regres = pd.concat([df_regres, df_all]).reset_index()
-    df_regres["sex"] = df_regres["sex"].str.lower()
-    
-    return df_regres
-
-
-def add_stratum(df, df_stratum):
-    # Create latitude bins from the stratum definitions
-    lat_bins = [-90.0] + df_stratum["latitude_northern_limit"].tolist() + [90.0]
-    lat_labels = df_stratum["stratum"].tolist() + [max(df_stratum["stratum"]) + 1]
-
-    # Add stratum column based on latitude
-    df["stratum"] = pd.cut(
-        df["latitude"],
-        bins=lat_bins,
-        labels=lat_labels,
-        include_lowest=True
-    )
-
-    return df
-
-
-def get_sigma_bs_mean_stratum(
-    df_length_count: pd.DataFrame,
-) -> pd.DataFrame:
-    # Compute sigma_bs for each row
-    df_length_count["sigma_bs"] = 10 ** ((
-        TS_L_PARAMS["slope"] * np.log10(df_length_count["length"])
-        + TS_L_PARAMS["intercept"]
-    ) / 10)
-
-    # Get mean sigma_bs for each stratum
-    return df_length_count.groupby("stratum").apply(
-        lambda df: pd.Series(
-            (df["sigma_bs"] * df["frequency"]).sum() / df["frequency"].sum(),
-            index=["sigma_bs_mean"],
-        ),
-        include_groups=False
-    ).reset_index()
-
-
-def get_weight_mean_stratum(
-    df_length_count: pd.DataFrame,
-    df_length_weight_regression: pd.DataFrame,
-) -> pd.DataFrame:
-    # Merge length-weight regression coefficients
-    df_merged = pd.merge(
-        df_length_count,
-        df_length_weight_regression[df_length_weight_regression["sex"] == "all"][["stratum", "p1", "p2"]],
-        on="stratum",
-        how="left"
-    )
-
-    # Then compute weight using the length-weight relationship: W = 10^(p1 * log10(L) + p2)
-    df_merged["weight"] = 10 ** (
-        df_merged["p1"] * np.log10(df_merged["length"]) + df_merged["p2"]
-    )
-
-    # Get mean weight for each stratum
-    return df_merged.groupby("stratum").apply(
-        lambda df: pd.Series(
-            (df["weight"] * df["frequency"]).sum() / df["frequency"].sum(),
-            index=["weight_mean"],
-        ),
-        include_groups=False
-    ).reset_index()
+from prefect import flow
 
 
 @flow(log_prints=True)
 def flow_ingest_haul(
-    path_vm_local: str = data_path,
+    path_vm_local: str = "VM_LOCAL_PATH",
     path_bio_files: str = "BIO_CSV_CLOUD_LOCATION",
     cred_file: str = "CREDENTIAL_FILE",
     file_haul_info_all: str = "haul_info_all.csv",
@@ -225,9 +57,9 @@ def flow_ingest_haul(
         print(f"No biology files found.")
         return
 
-    # Get valid haul numbers (those with 4 files)
+    # Get complete haul inventories (those with all four file types)
     hauls_valid = get_valid_hauls(bio_filenames)
-    print("Valid hauls:", hauls_valid)
+    print("Valid hauls:", list(hauls_valid))
 
     # Get hauls to process
     if not file_haul_info_all.exists():
@@ -236,7 +68,7 @@ def flow_ingest_haul(
     else:            
         df_haul_info_all = pd.read_csv(file_haul_info_all, index_col=0)
         hauls_processed = set(df_haul_info_all["haul"].unique())
-    hauls_to_process = list(hauls_valid.difference(hauls_processed))
+    hauls_to_process = sorted(set(hauls_valid).difference(hauls_processed))
 
     if not hauls_to_process:  # if there are hauls to process
         print(f"No hauls to process.")
@@ -251,7 +83,8 @@ def flow_ingest_haul(
         df_specimen = []
         df_info = []
         for haul_num in hauls_to_process:
-            with fs.open(f"{path_bio_files}/LengthFreq/{haul_num:03d}_LFdata.xlsx") as f:
+            haul_files = hauls_valid[haul_num]
+            with fs.open(haul_files["length"]) as f:
                 df_length_temp = pd.read_excel(f, index_col=0, sheet_name="Codend").reset_index().drop("Sum", axis=1)
                 df_length_temp = df_length_temp.melt(
                     id_vars=["length"],
@@ -260,12 +93,12 @@ def flow_ingest_haul(
                 ).assign(haul=haul_num)
                 df_length_temp["frequency"] = df_length_temp["frequency"].fillna(0).astype(int)
                 df_length.append(df_length_temp)
-            with fs.open(f"{path_bio_files}/Specimens/{haul_num:03d}_specimens.xlsx") as f:
+            with fs.open(haul_files["specimen"]) as f:
                 df_specimen.append(
                     pd.read_excel(f, index_col=0, sheet_name="Codend")
                     .reset_index().assign(haul=haul_num)
                 )
-            with fs.open(f"{path_bio_files}/NetConfig/202506_{haul_num:03d}_NetConfig.xlsx") as f:
+            with fs.open(haul_files["info"]) as f:
                 df_info_temp = (
                     pd.read_excel(f, index_col=0, sheet_name="ButtonPresses").reset_index()
                     .rename(columns=INFO_DATAFRAME_MAPPING)
@@ -346,4 +179,3 @@ def flow_ingest_haul(
             how="outer"
         )
         df_stratum.to_csv(file_stratum_mean)
-

--- a/src/echodataflow/flows/flows_biology.py
+++ b/src/echodataflow/flows/flows_biology.py
@@ -1,19 +1,22 @@
-from pathlib import Path
-import pandas as pd
+from __future__ import annotations
 
-import configparser, s3fs
+import configparser
+from pathlib import Path
+
+import pandas as pd
+import s3fs
+from prefect import flow
 
 from echodataflow.operations.operations_biology import (
-    add_stratum,
-    get_count_from_length_specimen,
-    get_length_weight_regression,
-    get_sigma_bs_mean_stratum,
-    get_weight_mean_stratum,
+    assign_strata,
+    combine_biology_data,
+    compute_stratum_estimates,
+    get_hauls_to_process,
+    load_haul_data,
+    read_biology_data,
+    write_biology_outputs,
 )
-from echodataflow.utils.const import INFO_DATAFRAME_MAPPING
-from echodataflow.utils.trawl_files import get_valid_hauls
-
-from prefect import flow
+from echodataflow.utils.trawl_files import discover_trawl_files, get_valid_hauls
 
 
 @flow(log_prints=True)
@@ -26,17 +29,20 @@ def flow_ingest_haul(
     file_length_all: str = "length_all.csv",
     file_length_count_all: str = "length_count_all.csv",
     file_stratum_mean: str = "stratum_mean.csv",
+    path_stratum_def: str = "inpfc_def.csv",
 ):
+    """Ingest complete cloud trawl hauls and recompute biological estimates."""
+    # Assemble the four accumulated output paths and the derived estimate path
+    output_directory = Path(path_vm_local)
+    output_paths = {
+        "haul_info": output_directory / file_haul_info_all,
+        "specimens": output_directory / file_specimen_all,
+        "lengths": output_directory / file_length_all,
+        "length_counts": output_directory / file_length_count_all,
+    }
+    stratum_mean_path = output_directory / file_stratum_mean
 
-    # Assemble full paths
-    path_vm_local: Path = Path(path_vm_local)
-    file_haul_info_all: Path = path_vm_local / file_haul_info_all
-    file_specimen_all: Path = path_vm_local / file_specimen_all
-    file_length_all: Path = path_vm_local / file_length_all
-    file_length_count_all: Path = path_vm_local / file_length_count_all
-    file_stratum_mean: Path = path_vm_local / file_stratum_mean
-
-    # Get cloud bucket
+    # Connect to the S3-compatible biology data store
     config = configparser.ConfigParser()
     config.read(cred_file)
     fs = s3fs.S3FileSystem(
@@ -45,137 +51,42 @@ def flow_ingest_haul(
         client_kwargs={"endpoint_url": config["osn_sdsc_hake"]["endpoint"]},
     )
 
-    bio_filenames = {
-        "length": fs.glob(f"{path_bio_files}/*/*_LFdata.xlsx"),
-        "specimen": fs.glob(f"{path_bio_files}/*/*_specimens.xlsx"),
-        "catch": fs.glob(f"{path_bio_files}/*/*_CatchPerc.xlsx"),
-        "info": fs.glob(f"{path_bio_files}/*/*_NetConfig.xlsx"),
-    }
-
-    # Exist if no file present
-    if not any(bio_filenames.values()):
-        print(f"No biology files found.")
+    # A haul is ready only after all four expected workbook types are present
+    discovered_files = discover_trawl_files(fs, path_bio_files)
+    if not any(discovered_files.values()):
+        print("No biology files found.")
         return
 
-    # Get complete haul inventories (those with all four file types)
-    hauls_valid = get_valid_hauls(bio_filenames)
-    print("Valid hauls:", list(hauls_valid))
+    valid_hauls = get_valid_hauls(discovered_files)
+    print("Valid hauls:", list(valid_hauls))
 
-    # Get hauls to process
-    if not file_haul_info_all.exists():
-        df_haul_info_all = pd.DataFrame()
-        hauls_processed = set()
-    else:            
-        df_haul_info_all = pd.read_csv(file_haul_info_all, index_col=0)
-        hauls_processed = set(df_haul_info_all["haul"].unique())
-    hauls_to_process = sorted(set(hauls_valid).difference(hauls_processed))
-
-    if not hauls_to_process:  # if there are hauls to process
-        print(f"No hauls to process.")
+    # Process only complete hauls not already in accumulated output
+    existing_hauls = read_biology_data(output_paths)
+    hauls_to_process = get_hauls_to_process(valid_hauls, existing_hauls.haul_info)
+    if not hauls_to_process:
+        print("No new hauls to process.")
         return
-    else:
-        print(
-            f"Processing {len(hauls_to_process)} hauls for :\n",
-            hauls_to_process
-        )
-        # Load dataframes from all hauls to process
-        df_length = []
-        df_specimen = []
-        df_info = []
-        for haul_num in hauls_to_process:
-            haul_files = hauls_valid[haul_num]
-            with fs.open(haul_files["length"]) as f:
-                df_length_temp = pd.read_excel(f, index_col=0, sheet_name="Codend").reset_index().drop("Sum", axis=1)
-                df_length_temp = df_length_temp.melt(
-                    id_vars=["length"],
-                    var_name="sex", 
-                    value_name="frequency"
-                ).assign(haul=haul_num)
-                df_length_temp["frequency"] = df_length_temp["frequency"].fillna(0).astype(int)
-                df_length.append(df_length_temp)
-            with fs.open(haul_files["specimen"]) as f:
-                df_specimen.append(
-                    pd.read_excel(f, index_col=0, sheet_name="Codend")
-                    .reset_index().assign(haul=haul_num)
-                )
-            with fs.open(haul_files["info"]) as f:
-                df_info_temp = (
-                    pd.read_excel(f, index_col=0, sheet_name="ButtonPresses").reset_index()
-                    .rename(columns=INFO_DATAFRAME_MAPPING)
-                )
-                df_info.append(
-                    # reset index to get haul number into a column
-                    df_info_temp[df_info_temp["button"] == "NIW"][["haul", "timestamp", "latitude", "longitude"]]
-                )
-        df_length = pd.concat(df_length, ignore_index=True)
-        df_specimen = pd.concat(df_specimen, ignore_index=True)
-        df_info = pd.concat(df_info, ignore_index=True)
 
-        # Combined length frequency from length and specimen dataframes
-        df_length_count = get_count_from_length_specimen(df_length, df_specimen)
+    print(f"Processing {len(hauls_to_process)} hauls:\n", hauls_to_process)
+    # Load every haul before publishing anything so one failure aborts the batch
+    new_hauls = combine_biology_data(
+        load_haul_data(fs, haul_num, valid_hauls[haul_num]) for haul_num in hauls_to_process
+    )
+    combined_hauls = combine_biology_data([existing_hauls, new_hauls])
 
-        # Add haul number and lat/lon for downstream stratification
-        df_specimen = pd.merge(
-            df_specimen,
-            df_info,
-            on="haul",
-            how="left"
-        )
-        df_length = pd.merge(
-            df_length,
-            df_info,
-            on="haul",
-            how="left"
-        )
-        df_length_count = pd.merge(
-            df_length_count,
-            df_info,
-            on="haul",
-            how="left"
-        )
+    # Assign strata to accumulated records, then recompute estimates from full history
+    stratum_definitions = (
+        pd.read_csv(path_stratum_def, index_col=0)
+        .reset_index()
+        .rename(columns={"stratum_num": "stratum"})
+    )
+    combined_hauls = assign_strata(combined_hauls, stratum_definitions)
+    stratum_mean = compute_stratum_estimates(combined_hauls, stratum_definitions)
 
-        # Update df_haul_info_all, df_specimen_all, df_length_all
-        df_specimen_all = pd.read_csv(file_specimen_all, index_col=0) if file_specimen_all.exists() else pd.DataFrame()
-        df_length_all = pd.read_csv(file_length_all, index_col=0) if file_length_all.exists() else pd.DataFrame()
-        df_length_count_all = pd.read_csv(file_length_count_all, index_col=0) if file_length_count_all.exists() else pd.DataFrame()
-        df_haul_info_all = pd.read_csv(file_haul_info_all, index_col=0) if file_haul_info_all.exists() else pd.DataFrame()
-
-        df_specimen_all = pd.concat([df_specimen_all, df_specimen], ignore_index=True)
-        df_length_all = pd.concat([df_length_all, df_length], ignore_index=True)
-        df_length_count_all = pd.concat([df_length_count_all, df_length_count], ignore_index=True)
-        df_haul_info_all = pd.concat([df_haul_info_all, df_info], ignore_index=True)
-
-        # Add stratrum info to df_specimen and df_length_count based on latitude
-        df_stratum = pd.read_csv(
-            Path(__file__).parent / "inpfc_def.csv", index_col=0
-        ).reset_index().rename(columns={"stratum_num": "stratum"})
-        df_specimen_all = add_stratum(df_specimen_all, df_stratum)
-        df_length_all = add_stratum(df_length_all, df_stratum)
-        df_length_count_all = add_stratum(df_length_count_all, df_stratum)
-        df_haul_info_all = add_stratum(df_haul_info_all, df_stratum)
-
-        # Save updated dataframes
-        df_specimen_all.to_csv(file_specimen_all)
-        df_length_all.to_csv(file_length_all)
-        df_length_count_all.to_csv(file_length_count_all)
-        df_haul_info_all.to_csv(file_haul_info_all)
-
-        # Compute length-weight relationship for each stratum
-        # Separately for: male, female, all fish combined
-        df_length_weight_regression = get_length_weight_regression(df_specimen_all)
-
-        # Compute mean sigma_bs and mean weight for each stratum
-        # columns: stratum, sigma_bs_mean, weight_mean
-        df_stratum = pd.merge(
-            df_stratum,
-            get_sigma_bs_mean_stratum(df_length_count_all),
-            on="stratum",
-            how="outer"
-        )
-        df_stratum = pd.merge(
-            df_stratum,
-            get_weight_mean_stratum(df_length_count_all, df_length_weight_regression),
-            on="stratum",
-            how="outer"
-        )
-        df_stratum.to_csv(file_stratum_mean)
+    # Update all accumulated datasets and estimates as one rollback-protected update
+    write_biology_outputs(
+        combined_hauls,
+        stratum_mean,
+        output_paths,
+        stratum_mean_path,
+    )

--- a/src/echodataflow/flows/flows_integration.py
+++ b/src/echodataflow/flows/flows_integration.py
@@ -12,7 +12,7 @@ import echopype as ep
 
 from echodataflow.utils.const import GRID_PARAMS
 from echodataflow.utils.grid import create_boundary_gdf, create_grid_from_bounds
-from echodataflow.flows.flows_biology import add_stratum
+from echodataflow.operations.operations_biology import add_stratum
 
 from prefect import task, flow, get_run_logger
 

--- a/src/echodataflow/flows/flows_integration.py
+++ b/src/echodataflow/flows/flows_integration.py
@@ -52,6 +52,11 @@ def flow_ingest_NASC(
     file_stratum_mean = Path(path_vm_local) / file_stratum_mean
     file_NASC_all_grid = Path(path_vm_local) / file_NASC_all_grid
 
+    # Wait for biological estimates from the upstream haul-ingestion flow
+    if not file_stratum_mean.exists():
+        logger.info(f"Upstream stratum estimates are not ready: {file_stratum_mean}")
+        return
+
     # Read accumulated data before planning new work
     df_NASC_existing = read_accumulated_NASC(file_NASC_all)
     NASC_processed = (
@@ -163,8 +168,17 @@ def flow_update_grid(
     file_stratum_mean: str = "stratum_mean.csv",
 ):
     """Update grid-cell estimates from integrated NASC and haul biology."""
+    logger = get_run_logger()
     file_NASC_all_grid = Path(path_vm_local) / file_NASC_all_grid
     file_stratum_mean = Path(path_vm_local) / file_stratum_mean
+
+    # Wait until both upstream integration products are available
+    missing_inputs = [path for path in [file_NASC_all_grid, file_stratum_mean] if not path.exists()]
+    if missing_inputs:
+        logger.info(
+            "Upstream grid inputs are not ready: " + ", ".join(str(path) for path in missing_inputs)
+        )
+        return
 
     # Refresh estimates on existing observations without changing their grid assignment
     gdf_NASC_all_grid = gpd.read_file(file_NASC_all_grid)

--- a/src/echodataflow/flows/flows_integration.py
+++ b/src/echodataflow/flows/flows_integration.py
@@ -1,125 +1,32 @@
-from pathlib import Path
-import numpy as np
-import pandas as pd
-import xarray as xr
+from __future__ import annotations
 
-import s3fs
 import configparser
-from geopy.distance import distance
-import geopandas as gpd
+from pathlib import Path
 
 import echopype as ep
+import geopandas as gpd
+import pandas as pd
+import s3fs
+from prefect import flow, get_run_logger
+from prefect.futures import as_completed
 
+from echodataflow.operations.operations_integration import (
+    ReadNASCSettings,
+    ReadNASCWorkItem,
+    add_biological_estimates,
+    aggregate_NASC_to_grid,
+    assign_NASC_to_grid,
+    plan_NASC_ingestion,
+    read_accumulated_NASC,
+    write_NASC_outputs,
+)
+from echodataflow.tasks.tasks_integration import task_read_NASC
 from echodataflow.utils.const import GRID_PARAMS
 from echodataflow.utils.grid import create_boundary_gdf, create_grid_from_bounds
-from echodataflow.operations.operations_biology import add_stratum
-
-from prefect import task, flow, get_run_logger
-
 
 # Turn on verbose logging for echopype
 # otherwise all logging will be muted
 ep.utils.log.verbose()
-
-
-# Set up paths
-data_main = "/Users/feresa/code_git/echodataflow/temp_bio"
-NASC_path = "nasc_zarr"
-
-
-# Create boundary GeoDataFrame with UTM projection
-gdf_boundary, gdf_boundary_utm, utm_num = create_boundary_gdf(
-    bounds=GRID_PARAMS["bounds"], 
-    projection=GRID_PARAMS["projection"]
-)
-
-
-
-@task(log_prints=True)
-def task_combine_NASC_to_dataframe(
-    fs: s3fs.S3FileSystem,
-    path_NASC_files: str,
-    NASC_filenames: list,
-) -> list[pd.DataFrame, list]:
-    """
-    Combine multiple NASC datasets into a single DataFrame.
-
-    Parameters
-    ----------
-    path_NASC_files : str
-        Path to the directory containing NASC zarr files.
-    NASC_filenames : list
-        List of NASC zarr filenames to process.
-        Not the full path, just the filenames.
-    """
-    df_NASC_list = []
-    errors = []
-    for nascf in NASC_filenames:
-        try:
-            print(f"Processing {nascf}...")
-            mapper = fs.get_mapper(str(Path(path_NASC_files) / nascf))
-            ds_NASC = xr.open_zarr(mapper, consolidated=True)
-            ds_NASC = ep.consolidate.swap_dims_channel_frequency(ds_NASC)
-            df_NASC = ds_NASC.sum("depth").sel(frequency_nominal=38000).to_dataframe()
-            df_NASC["filename"] = nascf
-            df_NASC_list.append(df_NASC)
-        except Exception as e:
-            errors.append(e)
-            print(f"Error processing {nascf}: {e}")
-            continue
-
-    if len(df_NASC_list) == 0:
-        return None, None
-    else:
-        return pd.concat(df_NASC_list, ignore_index=True), errors
-
-
-@task(log_prints=True)
-def task_griddify_NASC(
-    df_stratum: pd.DataFrame,
-    df_NASC: pd.DataFrame,
-    utm_num: int = utm_num,
-    gdf_boundary_utm: gpd.GeoDataFrame = gdf_boundary_utm,
-) -> gpd.GeoDataFrame:
-    """
-    Generate geodataframe with grid x/y containing NASC values.
-    """
-    # Convert to GeoDataFrame
-    gdf_NASC = gpd.GeoDataFrame(
-        data=df_NASC,
-        geometry=gpd.points_from_xy(df_NASC["longitude"], df_NASC["latitude"]),
-        crs=GRID_PARAMS["projection"],
-    ).to_crs(f"epsg:{utm_num}")
-
-    # Extract x y coordinate for pd.cut below
-    gdf_NASC["utm_x"] = gdf_NASC["geometry"].x
-    gdf_NASC["utm_y"] = gdf_NASC["geometry"].y
-
-    # Get grid step sizes and boundary x/y
-    x_step = distance(nautical=GRID_PARAMS["resolution"]["x_distance"]).meters
-    y_step = distance(nautical=GRID_PARAMS["resolution"]["y_distance"]).meters
-    xmin, ymin, xmax, ymax = gdf_boundary_utm.total_bounds
-
-    # Bin longitude and latitude into grids
-    gdf_NASC["grid_x"] = pd.cut(
-        gdf_NASC["utm_x"],
-        np.arange(xmin, xmax + x_step, x_step),
-        right=False,
-        labels=np.arange(1, len(np.arange(xmin, xmax + x_step, x_step))),
-    )
-
-    # Bin the latitude data
-    gdf_NASC["grid_y"] = pd.cut(
-        gdf_NASC["utm_y"],
-        np.arange(ymin, ymax + y_step, y_step),
-        right=True,
-        labels=np.arange(1, len(np.arange(ymin, ymax + y_step, y_step))),
-    )
-
-    # Add stratum info
-    gdf_NASC = add_stratum(gdf_NASC, df_stratum)
-
-    return gdf_NASC
 
 
 @flow(log_prints=True)
@@ -132,44 +39,27 @@ def flow_ingest_NASC(
     file_NASC_all_grid: str = "NASC_all_griddify.geojson",
     num_NASC_reprocess: int = 1,
     new_file_num_limit: int = 50,
+    frequency_nominal: int = 38000,
 ):
-    """
-    Ingest NASC data from zarr files and combine into a single DataFrame.
-    """
+    """Ingest cloud NASC stores and integrate them with biological estimates."""
     logger = get_run_logger()
-
-    # Ensure num_NASC_reprocess is at least 1
     if num_NASC_reprocess < 1:
-        num_NASC_reprocess = 1
-        raise Warning("num_NASC_reprocess must be at least 1, setting it to 1.")
+        raise ValueError("num_NASC_reprocess must be at least 1")
+    if new_file_num_limit < -1:
+        raise ValueError("new_file_num_limit must be -1 or non-negative")
 
-    # Get NASC files already processed
     file_NASC_all = Path(path_vm_local) / file_NASC_all
-    df_NASC_all = (
-        pd.read_csv(
-            file_NASC_all,
-            index_col=0,
-            date_format="ISO8601",
-            parse_dates=["ping_time"]
-        )
-        if file_NASC_all.exists() else pd.DataFrame()
-    )
+    file_stratum_mean = Path(path_vm_local) / file_stratum_mean
+    file_NASC_all_grid = Path(path_vm_local) / file_NASC_all_grid
+
+    # Read accumulated data before planning new work
+    df_NASC_existing = read_accumulated_NASC(file_NASC_all)
     NASC_processed = (
-        sorted(df_NASC_all["filename"].unique().tolist())
-        if not df_NASC_all.empty else []
+        sorted(df_NASC_existing["filename"].unique()) if not df_NASC_existing.empty else []
     )
     logger.info(f"NASC files already processed: {NASC_processed}")
 
-    # Reprocess the last num_NASC_reprocess files
-    NASC_to_reprocess = NASC_processed[-num_NASC_reprocess:]
-    NASC_processed = NASC_processed[:-num_NASC_reprocess]
-    logger.info(f"NASC files to reprocess: {NASC_to_reprocess}")
-
-    # Remove df_NASC_all entries that match files to reprocess
-    if not df_NASC_all.empty:
-        df_NASC_all = df_NASC_all[~df_NASC_all["filename"].isin(NASC_to_reprocess)]
-
-    # Get cloud bucket
+    # Connect to the S3-compatible NASC data store
     config = configparser.ConfigParser()
     config.read(cred_file)
     fs = s3fs.S3FileSystem(
@@ -178,86 +68,92 @@ def flow_ingest_NASC(
         client_kwargs={"endpoint_url": config["osn_sdsc_hake"]["endpoint"]},
     )
 
-    # Get all NASC files in the bucket
-    NASC_all = fs.glob(f"{path_NASC_files}/*.zarr")
-    NASC_all = sorted([Path(f).name for f in NASC_all])
-    logger.info(f"All NASC files: {NASC_all}")
-
-    # Determine which files to process
-    NASC_to_process = sorted(list(set(NASC_all).difference(set(NASC_processed))))
-
-    if len(NASC_to_process) == 0:
-        logger.info("No new NASC files to process.")
+    NASC_available = sorted(
+        Path(filename).name for filename in fs.glob(f"{path_NASC_files}/*.zarr")
+    )
+    logger.info(f"All NASC files: {NASC_available}")
+    NASC_to_process, NASC_to_replace = plan_NASC_ingestion(
+        NASC_available,
+        NASC_processed,
+        num_NASC_reprocess,
+        new_file_num_limit,
+    )
+    if not NASC_to_process:
+        logger.info("No new NASC files to process")
         return
-    else:
 
-        # Limit number of new files to process
-        if new_file_num_limit != -1 and len(NASC_to_process) > new_file_num_limit:
-            print(
-                f"More than {new_file_num_limit} new files to process. "
-                f"Limiting to first {new_file_num_limit} files."
-            )
-            NASC_to_process = NASC_to_process[:new_file_num_limit]
+    # Remove only rows for reprocessing files selected in this limited batch
+    if NASC_to_replace:
+        df_NASC_existing = df_NASC_existing[
+            ~df_NASC_existing["filename"].isin(NASC_to_replace)
+        ].copy()
+    logger.info(f"NASC files to replace: {NASC_to_replace}")
+    logger.info("Files to process:\n" + "".join(f"- {name}\n" for name in NASC_to_process))
 
-        # Print list of files to process
-        files_to_process = ""
-        for nascf in NASC_to_process:
-            files_to_process += f"- {nascf}\n"
-        logger.info(f"Files to process:\n{files_to_process}")
+    # Submit one task per store for independent retries and failure visibility
+    settings = ReadNASCSettings(
+        filesystem=fs,
+        input_directory=path_NASC_files,
+        frequency_nominal=frequency_nominal,
+    )
+    future_to_filename = {
+        task_read_NASC.with_options(
+            task_run_name=filename,
+            name=filename,
+            retries=3,
+        ).submit(ReadNASCWorkItem(filename=filename), settings): filename
+        for filename in NASC_to_process
+    }
 
-        # Combine all unprocessed NASC datasets into a single DataFrame
-        df_NASC, errors = task_combine_NASC_to_dataframe(fs, path_NASC_files, NASC_to_process)
-        if df_NASC is not None:
-            logger.info(f"df_NASC contains: {list(df_NASC["filename"].unique())}")
+    successful_dataframes = []
+    errors = []
+    for future in as_completed(future_to_filename):
+        filename = future_to_filename[future]
+        try:
+            successful_dataframes.append(future.result())
+        except Exception as error:
+            errors.append((filename, error))
+            logger.error(f"Failed to ingest {filename}: {error}")
 
-        # Append new NASC data to existing data
-        df_NASC_all = pd.concat([df_NASC_all, df_NASC], ignore_index=True)
-        if df_NASC_all is not None:
-            logger.info(f"after run df_NASC_all contains: {list(df_NASC_all["filename"].unique())}")
+    # Publish successful files even when another platform's store failed
+    if not successful_dataframes:
+        failed = ", ".join(filename for filename, _ in errors)
+        raise RuntimeError(f"All NASC files failed ingestion: {failed}")
 
-        # Sort by ping_time
-        df_NASC_all.sort_values(by="ping_time", inplace=True)
+    df_NASC_new = pd.concat(successful_dataframes, ignore_index=True)
+    df_NASC_all = (
+        pd.concat([df_NASC_existing, df_NASC_new], ignore_index=True)
+        if not df_NASC_existing.empty
+        else df_NASC_new.copy()
+    )
+    df_NASC_all.sort_values("ping_time", inplace=True)
 
-        # Load stratum means
-        df_stratum = pd.read_csv(Path(path_vm_local) / file_stratum_mean, index_col=0)
+    # Refresh biological estimates using the latest accumulated haul results
+    df_stratum = pd.read_csv(file_stratum_mean, index_col=0)
+    df_NASC_all = add_biological_estimates(df_NASC_all, df_stratum)
 
-        # Drop previous stratification to avoid merge conflicts
-        df_NASC_all = df_NASC_all.drop(
-            ["stratum", "sigma_bs_mean", "weight_mean"],
-            axis=1, errors='ignore'
-        )
+    # Assign each integrated observation to the configured survey grid
+    _, gdf_boundary_utm, utm_num = create_boundary_gdf(
+        bounds=GRID_PARAMS["bounds"],
+        projection=GRID_PARAMS["projection"],
+    )
+    gdf_NASC = assign_NASC_to_grid(
+        df_stratum,
+        df_NASC_all,
+        utm_num,
+        gdf_boundary_utm,
+    )
+    write_NASC_outputs(
+        df_NASC_all,
+        gdf_NASC,
+        file_NASC_all,
+        file_NASC_all_grid,
+    )
 
-        # Add stratum info
-        df_NASC_all = add_stratum(df_NASC_all, df_stratum)
-        df_NASC_all["stratum"] = df_NASC_all["stratum"].astype("Int64")  # convert from category to int
-
-        # Merge on stratum 
-        df_NASC_all = df_NASC_all.merge(
-            df_stratum[["stratum", "sigma_bs_mean", "weight_mean"]],
-            on="stratum",  # merge on stratum 
-            how="left"
-        )
-
-        # Compute stratified number density from NASC
-        df_NASC_all["number_density"] = df_NASC_all["NASC"] / df_NASC_all["sigma_bs_mean"]
-
-        # Compute biomass density from number density
-        df_NASC_all["biomass_density"] = df_NASC_all["number_density"] * df_NASC_all["weight_mean"]
-
-        # Save to combined NASC data to csv
-        df_NASC_all.to_csv(file_NASC_all)
-
-        # Griddify the NASC data
-        gdf_NASC = task_griddify_NASC(
-            df_stratum=df_stratum,
-            df_NASC=df_NASC_all,
-            utm_num=utm_num,
-            gdf_boundary_utm=gdf_boundary_utm
-        )
-        gdf_NASC.to_file(Path(path_vm_local) / file_NASC_all_grid, driver="GeoJSON")
-
-
-        # TODO: add error handling
+    # Mark the flow failed if any error occurred
+    if errors:
+        failed = ", ".join(filename for filename, _ in errors)
+        raise RuntimeError(f"Failed to ingest {len(errors)} NASC files: {failed}")
 
 
 @flow(log_prints=True)
@@ -266,90 +162,26 @@ def flow_update_grid(
     file_NASC_all_grid: str = "NASC_all_griddify.geojson",
     file_stratum_mean: str = "stratum_mean.csv",
 ):
-    """
-    Update the grid with the latest NASC data and stratum means from hauls.
-    """
-    # Assemble full paths
+    """Update grid-cell estimates from integrated NASC and haul biology."""
     file_NASC_all_grid = Path(path_vm_local) / file_NASC_all_grid
     file_stratum_mean = Path(path_vm_local) / file_stratum_mean
 
-    # Load griddified NASC and grid cells
-    gdf_NASC = gpd.read_file(file_NASC_all_grid)
-
-    # Load stratum means
+    # Refresh estimates on existing observations without changing their grid assignment
+    gdf_NASC_all_grid = gpd.read_file(file_NASC_all_grid)
     df_stratum = pd.read_csv(file_stratum_mean, index_col=0)
+    gdf_NASC_all_grid = add_biological_estimates(
+        gdf_NASC_all_grid,
+        df_stratum,
+        reassign_strata=False,
+    )
 
-    # Create gdf_grid_cells
+    # Create the complete survey grid and aggregate observation densities into cells
     gdf_grid_cells, _, _ = create_grid_from_bounds(
-        bounds=GRID_PARAMS["bounds"], 
+        bounds=GRID_PARAMS["bounds"],
         resolution=GRID_PARAMS["resolution"],
         projection=GRID_PARAMS["projection"],
         coastline_resolution="10m",
-        area_threshold=5
+        area_threshold=5,
     )
-    gdf_grid_cells.set_index(["grid_x", "grid_y"], inplace=True)
-
-    # Drop sigma_bs_mean and weight_mean to avoid merge conflicts
-    gdf_NASC = gdf_NASC.drop(
-        ["sigma_bs_mean", "weight_mean"],
-        axis=1, errors='ignore'
-    )
-
-    # Merge on stratum 
-    gdf_NASC = gdf_NASC.merge(
-        df_stratum[["stratum", "sigma_bs_mean", "weight_mean"]],
-        on="stratum",  # merge on stratum 
-        how="left"
-    )
-
-    # Compute stratified number density from NASC
-    gdf_NASC["number_density"] = gdf_NASC["NASC"] / gdf_NASC["sigma_bs_mean"]
-
-    # Compute biomass density from number density
-    gdf_NASC["biomass_density"] = gdf_NASC["number_density"] * gdf_NASC["weight_mean"]
-
-    # Merge with grid cells
-    gdf_grid_cells = pd.merge(
-        gdf_grid_cells,
-        gdf_NASC.groupby(["grid_x", "grid_y"])["NASC"].mean(),
-        on=["grid_x", "grid_y"],
-        how="left"
-    )
-    gdf_grid_cells = pd.merge(
-        gdf_grid_cells,
-        gdf_NASC.groupby(["grid_x", "grid_y"])["number_density"].mean(),
-        on=["grid_x", "grid_y"],
-        how="left"
-    )
-    gdf_grid_cells = pd.merge(
-        gdf_grid_cells,
-        gdf_NASC.groupby(["grid_x", "grid_y"])["biomass_density"].mean(),
-        on=["grid_x", "grid_y"],
-        how="left"
-    )
-
-    # Compute abundance and biomass
-    gdf_grid_cells["abundance"] = gdf_grid_cells["number_density"] * gdf_grid_cells["area"]
-    gdf_grid_cells["biomass"] = gdf_grid_cells["biomass_density"] * gdf_grid_cells["area"]
-
-    # Save updated grid cells
+    gdf_grid_cells = aggregate_NASC_to_grid(gdf_NASC_all_grid, gdf_grid_cells)
     gdf_grid_cells.to_file(Path(path_vm_local) / "grid_cells.geojson", driver="GeoJSON")
-
-
-
-# @flow(log_prints=True)
-# def flow_test_trigger(trigger = True):
-#     if not trigger:
-#         return
-#     else:
-#         # Emit event when new NASC files are processed
-#         emit_event(
-#             event="test.processed",
-#             resource={"prefect.resource.id": "test_trigger"}
-#         )    
-
-# @flow(log_prints=True)
-# def flow_to_be_trigger():
-#     # Emit event when new NASC files are processed
-#     logger = get_run_logger()
-#     logger.info("This flow is triggered by an event emission.")

--- a/src/echodataflow/flows/flows_predict_hake.py
+++ b/src/echodataflow/flows/flows_predict_hake.py
@@ -119,7 +119,8 @@ async def flow_predict_hake(
 
     # Load Sv and MVBS info dataframes
     if not file_MVBS_csv.exists():
-        raise ValueError("MVBS info csv does not exist, check create_MVBS flow!")
+        logger.info("MVBS info csv does not exist, check create_MVBS flow!")
+        return
     df_MVBS = read_manifest(
         file_MVBS_csv,
         MVBS_COLUMNS_REALTIME,

--- a/src/echodataflow/flows/flows_simulation.py
+++ b/src/echodataflow/flows/flows_simulation.py
@@ -281,12 +281,7 @@ def flow_simulate_transects(
     if path_transect.exists():
         df = pd.read_csv(
             path_transect,
-            dtype={
-                "transectPart": "string",
-                "transectNumber": "string",
-                "transectStart": "string",
-                "transectEnd": "string",
-            },
+            dtype="string",
         )
     else:
         df = pd.DataFrame(
@@ -295,7 +290,8 @@ def flow_simulate_transects(
                 "transectNumber",
                 "transectStart",
                 "transectEnd",
-            ]
+            ],
+            dtype="string",
         )
 
     # ---------------------------------------------
@@ -310,7 +306,8 @@ def flow_simulate_transects(
                     "transectStart": transect_start.isoformat(),
                     "transectEnd": pd.NA,
                 }
-            ]
+            ],
+            dtype="string",
         )
 
         df = pd.concat(

--- a/src/echodataflow/flows/flows_simulation.py
+++ b/src/echodataflow/flows/flows_simulation.py
@@ -56,8 +56,7 @@ def flow_copy_raw(
 
     # Set flow execution time to current time - time_offset_seconds
     flow_time_curr = (
-        datetime.datetime.now()
-        - datetime.timedelta(seconds=time_offset_seconds)
+        datetime.datetime.now() - datetime.timedelta(seconds=time_offset_seconds)
     ).astimezone(datetime.timezone.utc)
     print(f"Simulated flow run start time: {flow_time_curr}")
 
@@ -141,9 +140,7 @@ def flow_copy_trawl(
     # Determine next trawl number from Prefect variable state
     trawl_num_prev = Variable.get(_var_key(prefix="prev_trawl_num"), default=None)
     trawl_num_curr = (
-        start_trawl_num
-        if trawl_num_prev is None
-        else int(trawl_num_prev) + trawl_num_step
+        start_trawl_num if trawl_num_prev is None else int(trawl_num_prev) + trawl_num_step
     )
     trawl_num_str = f"{trawl_num_curr:03d}"
     print(f"Previous trawl number: {trawl_num_prev}")
@@ -218,6 +215,7 @@ def flow_copy_trawl(
     print(f"Flow complete. Downloaded {len(results)} files for trawl {trawl_num_str}.")
     return results
 
+
 @flow(log_prints=True)
 def flow_simulate_transects(
     path_transect_csv: str,
@@ -229,20 +227,12 @@ def flow_simulate_transects(
     """Simulate realtime opening and closing of transects."""
 
     path_transect = Path(path_transect_csv)
-    path_transect.parent.mkdir(
-        parents=True,
-        exist_ok=True,
-    )
+    path_transect.parent.mkdir(parents=True, exist_ok=True)
 
-    survey_start_time = pd.to_datetime(
-        survey_start,
-        utc=True,
-    )
+    survey_start_time = pd.to_datetime(survey_start, utc=True)
 
-    state = Variable.get(
-        _var_key(prefix="transect_state"),
-        default=None,
-    )
+    transect_state_key = _var_key(prefix="transect_state")
+    state = Variable.get(transect_state_key, default=None)
 
     # ---------------------------------------------
     # First run: open first transect
@@ -260,29 +250,13 @@ def flow_simulate_transects(
 
     transect_num = f"{transect_num_curr:03d}"
 
-    transect_start = (
-        survey_start_time
-        + pd.Timedelta(
-            minutes=(
-                transect_num_curr
-                - start_transect_num
-            )
-            * transect_duration_minutes
-        )
-    )
+    transect_offset = (transect_num_curr - start_transect_num) * transect_duration_minutes
+    transect_start = survey_start_time + pd.Timedelta(minutes=transect_offset)
 
-    transect_end = (
-        transect_start
-        + pd.Timedelta(
-            minutes=transect_duration_minutes
-        )
-    )
+    transect_end = transect_start + pd.Timedelta(minutes=transect_duration_minutes)
 
     if path_transect.exists():
-        df = pd.read_csv(
-            path_transect,
-            dtype="string",
-        )
+        df = pd.read_csv(path_transect, dtype="string")
     else:
         df = pd.DataFrame(
             columns=[
@@ -310,60 +284,29 @@ def flow_simulate_transects(
             dtype="string",
         )
 
-        df = pd.concat(
-            [df, row],
-            ignore_index=True,
-        )
+        df = pd.concat([df, row], ignore_index=True)
 
-        df.to_csv(
-            path_transect,
-            index=False,
-        )
+        df.to_csv(path_transect, index=False)
 
-        Variable.set(
-            _var_key(prefix="transect_state"),
-            f"{transect_num_curr}:close",
-            overwrite=True,
-        )
+        Variable.set(transect_state_key, f"{transect_num_curr}:close", overwrite=True)
 
-        print(
-            f"Opened simulated transect {transect_num}: "
-            f"{transect_start}"
-        )
+        print(f"Opened simulated transect {transect_num}: {transect_start}")
 
         return
 
     # ---------------------------------------------
     # CLOSE transect
     # ---------------------------------------------
-    idx = (
-        df["transectPart"]
-        == transect_num
-    )
+    idx = df["transectPart"] == transect_num
 
     if not idx.any():
-        raise ValueError(
-            f"Cannot close transect {transect_num}: "
-            "transect not found in CSV."
-        )
+        message = f"Cannot close transect {transect_num}: transect not found in CSV."
+        raise ValueError(message)
 
-    df.loc[
-        idx,
-        "transectEnd",
-    ] = transect_end.isoformat()
+    df.loc[idx, "transectEnd"] = transect_end.isoformat()
 
-    df.to_csv(
-        path_transect,
-        index=False,
-    )
+    df.to_csv(path_transect, index=False)
 
-    print(
-        f"Closed simulated transect {transect_num}: "
-        f"{transect_end}"
-    )
+    print(f"Closed simulated transect {transect_num}: {transect_end}")
 
-    Variable.set(
-        _var_key(prefix="transect_state"),
-        f"{transect_num_curr + 1}:open",
-        overwrite=True,
-    )
+    Variable.set(transect_state_key, f"{transect_num_curr + 1}:open", overwrite=True)

--- a/src/echodataflow/operations/operations_biology.py
+++ b/src/echodataflow/operations/operations_biology.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 import numpy as np
 import pandas as pd
 
+from echodataflow.operations.operations_stratification import assign_stratum
 from echodataflow.utils.const import INFO_DATAFRAME_MAPPING, TS_L_PARAMS
 
 BIOLOGY_OUTPUT_KEYS = ("haul_info", "specimens", "lengths", "length_counts")
@@ -96,19 +97,6 @@ def get_length_weight_regression(df_specimen: pd.DataFrame) -> pd.DataFrame:
     df_regres = pd.concat([df_regres, df_all]).reset_index()
     df_regres["sex"] = df_regres["sex"].str.lower()
     return df_regres
-
-
-def add_stratum(df: pd.DataFrame, df_stratum: pd.DataFrame) -> pd.DataFrame:
-    """Return a copy with strata assigned from each observation's latitude."""
-    result = df.copy()
-
-    # Extend the configured northern limits to cover every possible latitude
-    lat_bins = [-90.0] + df_stratum["latitude_northern_limit"].tolist() + [90.0]
-    lat_labels = df_stratum["stratum"].tolist() + [max(df_stratum["stratum"]) + 1]
-    result["stratum"] = pd.cut(
-        result["latitude"], bins=lat_bins, labels=lat_labels, include_lowest=True
-    )
-    return result
 
 
 def get_sigma_bs_mean_stratum(df_length_count: pd.DataFrame) -> pd.DataFrame:
@@ -272,7 +260,7 @@ def assign_strata(data: BiologyData, stratum_definitions: pd.DataFrame) -> Biolo
     """Return biological data with strata assigned to every dataframe."""
     return BiologyData(
         **{
-            field.name: add_stratum(getattr(data, field.name), stratum_definitions)
+            field.name: assign_stratum(getattr(data, field.name), stratum_definitions)
             for field in fields(BiologyData)
         }
     )

--- a/src/echodataflow/operations/operations_biology.py
+++ b/src/echodataflow/operations/operations_biology.py
@@ -1,0 +1,137 @@
+"""Biological data transformations and estimates for trawl hauls."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from echodataflow.utils.const import TS_L_PARAMS
+
+
+def get_count_from_length_specimen(
+    df_length: pd.DataFrame,
+    df_specimen: pd.DataFrame,
+) -> pd.DataFrame:
+    """Combine length-frequency and specimen observations into length counts."""
+    # Round fish length to nearest integer
+    df_specimen["length"] = df_specimen["fork_length"].round(0).astype(int)
+
+    specimen_counts = (
+        df_specimen.groupby(["sex", "length", "haul"]).size().reset_index(name="frequency")
+    )
+    length_counts = (
+        df_length.groupby(["sex", "length", "haul"])
+        .agg({"frequency": "sum"})
+        .reset_index()
+    )
+
+    df_combined = pd.merge(
+        specimen_counts.reset_index(),
+        length_counts.reset_index(),
+        on=["sex", "length", "haul"],
+        how="outer",
+    ).fillna(0)
+    df_combined["frequency"] = (
+        df_combined["frequency_x"] + df_combined["frequency_y"]
+    ).astype(int)
+
+    return df_combined[["sex", "length", "frequency", "haul"]]
+
+
+def get_length_weight_regression(df_specimen: pd.DataFrame) -> pd.DataFrame:
+    """Get length-weight coefficients by sex and for all fish combined."""
+    df_regres = (
+        df_specimen.groupby(["sex", "stratum"])
+        .apply(
+            lambda df: pd.Series(
+                np.polyfit(np.log10(df["length"]), np.log10(df["organism_weight"]), 1),
+                index=["p1", "p2"],
+            ),
+            include_groups=False,
+        )
+        .reset_index()
+    )
+
+    df_all = (
+        df_specimen.groupby("stratum")
+        .apply(
+            lambda df: pd.Series(
+                np.polyfit(np.log10(df["length"]), np.log10(df["organism_weight"]), 1),
+                index=["p1", "p2"],
+            ),
+            include_groups=False,
+        )
+        .reset_index()
+    )
+    df_all["sex"] = "all"
+
+    df_regres = pd.concat([df_regres, df_all]).reset_index()
+    df_regres["sex"] = df_regres["sex"].str.lower()
+    return df_regres
+
+
+def add_stratum(df: pd.DataFrame, df_stratum: pd.DataFrame) -> pd.DataFrame:
+    """Assign strata based on each observation's latitude."""
+    lat_bins = [-90.0] + df_stratum["latitude_northern_limit"].tolist() + [90.0]
+    lat_labels = df_stratum["stratum"].tolist() + [max(df_stratum["stratum"]) + 1]
+
+    df["stratum"] = pd.cut(
+        df["latitude"],
+        bins=lat_bins,
+        labels=lat_labels,
+        include_lowest=True,
+    )
+    return df
+
+
+def get_sigma_bs_mean_stratum(df_length_count: pd.DataFrame) -> pd.DataFrame:
+    """Compute the frequency-weighted mean backscattering cross-section by stratum."""
+    df_length_count["sigma_bs"] = 10 ** (
+        (
+            TS_L_PARAMS["slope"] * np.log10(df_length_count["length"])
+            + TS_L_PARAMS["intercept"]
+        )
+        / 10
+    )
+
+    return (
+        df_length_count.groupby("stratum")
+        .apply(
+            lambda df: pd.Series(
+                (df["sigma_bs"] * df["frequency"]).sum() / df["frequency"].sum(),
+                index=["sigma_bs_mean"],
+            ),
+            include_groups=False,
+        )
+        .reset_index()
+    )
+
+
+def get_weight_mean_stratum(
+    df_length_count: pd.DataFrame,
+    df_length_weight_regression: pd.DataFrame,
+) -> pd.DataFrame:
+    """Compute frequency-weighted mean organism weight by stratum."""
+    df_merged = pd.merge(
+        df_length_count,
+        df_length_weight_regression[df_length_weight_regression["sex"] == "all"][
+            ["stratum", "p1", "p2"]
+        ],
+        on="stratum",
+        how="left",
+    )
+    df_merged["weight"] = 10 ** (
+        df_merged["p1"] * np.log10(df_merged["length"]) + df_merged["p2"]
+    )
+
+    return (
+        df_merged.groupby("stratum")
+        .apply(
+            lambda df: pd.Series(
+                (df["weight"] * df["frequency"]).sum() / df["frequency"].sum(),
+                index=["weight_mean"],
+            ),
+            include_groups=False,
+        )
+        .reset_index()
+    )

--- a/src/echodataflow/operations/operations_biology.py
+++ b/src/echodataflow/operations/operations_biology.py
@@ -1,11 +1,35 @@
-"""Biological data transformations and estimates for trawl hauls."""
+"""Biological data ingestion, transformations, and estimates for trawl hauls."""
 
 from __future__ import annotations
+
+import os
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, fields
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
 
 import numpy as np
 import pandas as pd
 
-from echodataflow.utils.const import TS_L_PARAMS
+from echodataflow.utils.const import INFO_DATAFRAME_MAPPING, TS_L_PARAMS
+
+BIOLOGY_OUTPUT_KEYS = ("haul_info", "specimens", "lengths", "length_counts")
+
+
+@dataclass
+class BiologyData:
+    """The related biological dataframes for one haul or an accumulated dataset."""
+
+    haul_info: pd.DataFrame
+    specimens: pd.DataFrame
+    lengths: pd.DataFrame
+    length_counts: pd.DataFrame
+
+    @classmethod
+    def empty(cls) -> BiologyData:
+        """Create a dataset containing four empty dataframes."""
+        return cls(*(pd.DataFrame() for _ in fields(cls)))
 
 
 def get_count_from_length_specimen(
@@ -13,33 +37,35 @@ def get_count_from_length_specimen(
     df_specimen: pd.DataFrame,
 ) -> pd.DataFrame:
     """Combine length-frequency and specimen observations into length counts."""
-    # Round fish length to nearest integer
-    df_specimen["length"] = df_specimen["fork_length"].round(0).astype(int)
+    # Round specimen lengths to the integer bins used by the length-frequency data
+    specimen = df_specimen.copy()
+    specimen["length"] = specimen["fork_length"].round(0).astype(int)
 
+    # Count individually measured specimens and aggregate recorded length frequencies
     specimen_counts = (
-        df_specimen.groupby(["sex", "length", "haul"]).size().reset_index(name="frequency")
+        specimen.groupby(["sex", "length", "haul"]).size().reset_index(name="frequency")
     )
     length_counts = (
-        df_length.groupby(["sex", "length", "haul"])
-        .agg({"frequency": "sum"})
-        .reset_index()
+        df_length.groupby(["sex", "length", "haul"]).agg({"frequency": "sum"}).reset_index()
     )
 
-    df_combined = pd.merge(
-        specimen_counts.reset_index(),
-        length_counts.reset_index(),
+    # A length bin can occur in either source, so retain the union and add both counts
+    combined = pd.merge(
+        specimen_counts,
+        length_counts,
         on=["sex", "length", "haul"],
         how="outer",
+        suffixes=("_specimen", "_length"),
     ).fillna(0)
-    df_combined["frequency"] = (
-        df_combined["frequency_x"] + df_combined["frequency_y"]
+    combined["frequency"] = (
+        combined["frequency_specimen"] + combined["frequency_length"]
     ).astype(int)
-
-    return df_combined[["sex", "length", "frequency", "haul"]]
+    return combined[["sex", "length", "frequency", "haul"]]
 
 
 def get_length_weight_regression(df_specimen: pd.DataFrame) -> pd.DataFrame:
     """Get length-weight coefficients by sex and for all fish combined."""
+    # Fit male and female relationships separately within each stratum
     df_regres = (
         df_specimen.groupby(["sex", "stratum"])
         .apply(
@@ -52,6 +78,7 @@ def get_length_weight_regression(df_specimen: pd.DataFrame) -> pd.DataFrame:
         .reset_index()
     )
 
+    # Fit a second relationship using all fish within each stratum
     df_all = (
         df_specimen.groupby("stratum")
         .apply(
@@ -65,37 +92,37 @@ def get_length_weight_regression(df_specimen: pd.DataFrame) -> pd.DataFrame:
     )
     df_all["sex"] = "all"
 
+    # Combine the sex-specific and all-fish coefficients with normalized labels
     df_regres = pd.concat([df_regres, df_all]).reset_index()
     df_regres["sex"] = df_regres["sex"].str.lower()
     return df_regres
 
 
 def add_stratum(df: pd.DataFrame, df_stratum: pd.DataFrame) -> pd.DataFrame:
-    """Assign strata based on each observation's latitude."""
+    """Return a copy with strata assigned from each observation's latitude."""
+    result = df.copy()
+
+    # Extend the configured northern limits to cover every possible latitude
     lat_bins = [-90.0] + df_stratum["latitude_northern_limit"].tolist() + [90.0]
     lat_labels = df_stratum["stratum"].tolist() + [max(df_stratum["stratum"]) + 1]
-
-    df["stratum"] = pd.cut(
-        df["latitude"],
-        bins=lat_bins,
-        labels=lat_labels,
-        include_lowest=True,
+    result["stratum"] = pd.cut(
+        result["latitude"], bins=lat_bins, labels=lat_labels, include_lowest=True
     )
-    return df
+    return result
 
 
 def get_sigma_bs_mean_stratum(df_length_count: pd.DataFrame) -> pd.DataFrame:
     """Compute the frequency-weighted mean backscattering cross-section by stratum."""
-    df_length_count["sigma_bs"] = 10 ** (
-        (
-            TS_L_PARAMS["slope"] * np.log10(df_length_count["length"])
-            + TS_L_PARAMS["intercept"]
-        )
-        / 10
+    length_count = df_length_count.copy()
+
+    # Convert the target-strength relationship into backscattering cross-section
+    length_count["sigma_bs"] = 10 ** (
+        (TS_L_PARAMS["slope"] * np.log10(length_count["length"]) + TS_L_PARAMS["intercept"]) / 10
     )
 
+    # Weight each length bin by the number of fish observed in that bin
     return (
-        df_length_count.groupby("stratum")
+        length_count.groupby("stratum")
         .apply(
             lambda df: pd.Series(
                 (df["sigma_bs"] * df["frequency"]).sum() / df["frequency"].sum(),
@@ -112,6 +139,7 @@ def get_weight_mean_stratum(
     df_length_weight_regression: pd.DataFrame,
 ) -> pd.DataFrame:
     """Compute frequency-weighted mean organism weight by stratum."""
+    # Attach the all-fish length-weight coefficients for each stratum
     df_merged = pd.merge(
         df_length_count,
         df_length_weight_regression[df_length_weight_regression["sex"] == "all"][
@@ -120,10 +148,11 @@ def get_weight_mean_stratum(
         on="stratum",
         how="left",
     )
-    df_merged["weight"] = 10 ** (
-        df_merged["p1"] * np.log10(df_merged["length"]) + df_merged["p2"]
-    )
 
+    # Evaluate W = 10^(p1 * log10(L) + p2) for every observed length bin
+    df_merged["weight"] = 10 ** (df_merged["p1"] * np.log10(df_merged["length"]) + df_merged["p2"])
+
+    # Weight the modeled value by the number of fish observed in each length bin
     return (
         df_merged.groupby("stratum")
         .apply(
@@ -135,3 +164,209 @@ def get_weight_mean_stratum(
         )
         .reset_index()
     )
+
+
+def read_biology_data(output_paths: Mapping[str, Path]) -> BiologyData:
+    """Read accumulated biological outputs, using empty dataframes on the first run."""
+    _validate_output_paths(output_paths)
+    return BiologyData(
+        **{
+            key: (
+                pd.read_csv(output_paths[key], index_col=0)
+                if output_paths[key].exists()
+                else pd.DataFrame()
+            )
+            for key in BIOLOGY_OUTPUT_KEYS
+        }
+    )
+
+
+def get_hauls_to_process(
+    valid_hauls: Mapping[int, Mapping[str, str]],
+    haul_info: pd.DataFrame,
+) -> list[int]:
+    """Return sorted valid haul numbers absent from accumulated haul information."""
+    if haul_info.empty:
+        processed: set[int] = set()
+    else:
+        if "haul" not in haul_info:
+            raise ValueError("Existing haul information is missing the 'haul' column")
+        processed = set(pd.to_numeric(haul_info["haul"], errors="raise").astype(int))
+    return sorted(set(valid_hauls).difference(processed))
+
+
+def load_haul_data(
+    fs: Any,
+    haul_num: int,
+    haul_files: Mapping[str, str],
+) -> BiologyData:
+    """Load and normalize the biological workbooks for one complete haul.
+
+    Catch files are required during haul discovery as a completeness signal,
+    but their contents are intentionally not ingested yet.
+    """
+    required = {"length", "specimen", "catch", "info"}
+    missing = required.difference(haul_files)
+    if missing:
+        raise ValueError(f"Haul {haul_num:03d} is missing file types: {sorted(missing)}")
+
+    # Convert the wide length-frequency worksheet to one row per sex and length bin
+    with fs.open(haul_files["length"]) as file:
+        lengths = (
+            pd.read_excel(file, index_col=0, sheet_name="Codend")
+            .reset_index()
+            .drop("Sum", axis=1)
+            .melt(id_vars=["length"], var_name="sex", value_name="frequency")
+            .assign(haul=haul_num)
+        )
+        lengths["frequency"] = lengths["frequency"].fillna(0).astype(int)
+
+    # Load individually measured fish and normalize fork length to the same bins
+    with fs.open(haul_files["specimen"]) as file:
+        specimens = (
+            pd.read_excel(file, index_col=0, sheet_name="Codend")
+            .reset_index()
+            .assign(haul=haul_num)
+        )
+        # Preserve the normalized length column in accumulated specimen output
+        specimens["length"] = specimens["fork_length"].round(0).astype(int)
+
+    # Keep the net-in-water event as the haul's time and geographic position
+    with fs.open(haul_files["info"]) as file:
+        haul_info = (
+            pd.read_excel(file, index_col=0, sheet_name="ButtonPresses")
+            .reset_index()
+            .rename(columns=INFO_DATAFRAME_MAPPING)
+        )
+        haul_info = haul_info[haul_info["button"] == "NIW"][
+            ["haul", "timestamp", "latitude", "longitude"]
+        ].copy()
+
+    # Combine both sources of length counts before attaching haul location metadata
+    length_counts = get_count_from_length_specimen(lengths, specimens)
+    locations = haul_info[["haul", "timestamp", "latitude", "longitude"]]
+    return BiologyData(
+        haul_info=haul_info,
+        specimens=pd.merge(specimens, locations, on="haul", how="left"),
+        lengths=pd.merge(lengths, locations, on="haul", how="left"),
+        length_counts=pd.merge(length_counts, locations, on="haul", how="left"),
+    )
+
+
+def combine_biology_data(datasets: Iterable[BiologyData]) -> BiologyData:
+    """Concatenate biological datasets without mutating their dataframes."""
+    datasets = list(datasets)
+    if not datasets:
+        return BiologyData.empty()
+    return BiologyData(
+        **{
+            field.name: pd.concat(
+                [getattr(dataset, field.name) for dataset in datasets], ignore_index=True
+            )
+            for field in fields(BiologyData)
+        }
+    )
+
+
+def assign_strata(data: BiologyData, stratum_definitions: pd.DataFrame) -> BiologyData:
+    """Return biological data with strata assigned to every dataframe."""
+    return BiologyData(
+        **{
+            field.name: add_stratum(getattr(data, field.name), stratum_definitions)
+            for field in fields(BiologyData)
+        }
+    )
+
+
+def compute_stratum_estimates(
+    data: BiologyData,
+    stratum_definitions: pd.DataFrame,
+) -> pd.DataFrame:
+    """Recompute biological estimates from the full accumulated dataset."""
+    # Refit the relationships from all accumulated specimens whenever data changes
+    regression = get_length_weight_regression(data.specimens)
+
+    # Add frequency-weighted backscatter and weight estimates to the definitions
+    estimates = pd.merge(
+        stratum_definitions.copy(),
+        get_sigma_bs_mean_stratum(data.length_counts),
+        on="stratum",
+        how="outer",
+    )
+    return pd.merge(
+        estimates,
+        get_weight_mean_stratum(data.length_counts, regression),
+        on="stratum",
+        how="outer",
+    )
+
+
+def write_biology_outputs(
+    data: BiologyData,
+    stratum_mean: pd.DataFrame,
+    output_paths: Mapping[str, Path],
+    stratum_mean_path: Path,
+) -> None:
+    """Stage every CSV, then store them as one rollback-protected update."""
+    _validate_output_paths(output_paths)
+    outputs = {
+        **{key: getattr(data, key) for key in BIOLOGY_OUTPUT_KEYS},
+        "stratum_mean": stratum_mean,
+    }
+    paths = {**output_paths, "stratum_mean": stratum_mean_path}
+    transaction_id = uuid4().hex
+    staged: dict[str, Path] = {}
+    backups: dict[str, Path] = {}
+    installed: list[str] = []
+
+    try:
+        # Serialize everything successfully before changing any published output
+        for key, dataframe in outputs.items():
+            target = paths[key]
+            target.parent.mkdir(parents=True, exist_ok=True)
+            stage = target.with_name(f".{target.name}.{transaction_id}.tmp")
+            dataframe.to_csv(stage)
+            staged[key] = stage
+
+        # Preserve old outputs so a failure during publication can be rolled back
+        for key, target in paths.items():
+            if target.exists():
+                backup = target.with_name(f".{target.name}.{transaction_id}.bak")
+                os.replace(target, backup)
+                backups[key] = backup
+            os.replace(staged[key], target)
+            installed.append(key)
+    except Exception:
+        # Remove newly installed files, then restore every available original
+        rollback_errors = []
+        for key in reversed(installed):
+            try:
+                paths[key].unlink(missing_ok=True)
+            except OSError as error:
+                rollback_errors.append(error)
+        for key, backup in backups.items():
+            try:
+                os.replace(backup, paths[key])
+            except OSError as error:
+                rollback_errors.append(error)
+        if rollback_errors:
+            raise RuntimeError(
+                "Biology output update failed and could not be fully rolled back"
+            ) from rollback_errors[0]
+        raise
+    else:
+        for backup in backups.values():
+            backup.unlink(missing_ok=True)
+    finally:
+        for stage in staged.values():
+            stage.unlink(missing_ok=True)
+
+
+def _validate_output_paths(output_paths: Mapping[str, Path]) -> None:
+    missing = set(BIOLOGY_OUTPUT_KEYS).difference(output_paths)
+    unexpected = set(output_paths).difference(BIOLOGY_OUTPUT_KEYS)
+    if missing or unexpected:
+        raise ValueError(
+            f"Invalid biology output paths: missing={sorted(missing)}, "
+            f"unexpected={sorted(unexpected)}"
+        )

--- a/src/echodataflow/operations/operations_biology.py
+++ b/src/echodataflow/operations/operations_biology.py
@@ -57,9 +57,9 @@ def get_count_from_length_specimen(
         how="outer",
         suffixes=("_specimen", "_length"),
     ).fillna(0)
-    combined["frequency"] = (
-        combined["frequency_specimen"] + combined["frequency_length"]
-    ).astype(int)
+    combined["frequency"] = (combined["frequency_specimen"] + combined["frequency_length"]).astype(
+        int
+    )
     return combined[["sex", "length", "frequency", "haul"]]
 
 
@@ -67,7 +67,7 @@ def get_length_weight_regression(df_specimen: pd.DataFrame) -> pd.DataFrame:
     """Get length-weight coefficients by sex and for all fish combined."""
     # Fit male and female relationships separately within each stratum
     df_regres = (
-        df_specimen.groupby(["sex", "stratum"])
+        df_specimen.groupby(["sex", "stratum"], observed=True)
         .apply(
             lambda df: pd.Series(
                 np.polyfit(np.log10(df["length"]), np.log10(df["organism_weight"]), 1),
@@ -80,7 +80,7 @@ def get_length_weight_regression(df_specimen: pd.DataFrame) -> pd.DataFrame:
 
     # Fit a second relationship using all fish within each stratum
     df_all = (
-        df_specimen.groupby("stratum")
+        df_specimen.groupby("stratum", observed=True)
         .apply(
             lambda df: pd.Series(
                 np.polyfit(np.log10(df["length"]), np.log10(df["organism_weight"]), 1),

--- a/src/echodataflow/operations/operations_integration.py
+++ b/src/echodataflow/operations/operations_integration.py
@@ -1,0 +1,240 @@
+"""Operations for integrating acoustic and biological survey products."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from uuid import uuid4
+
+import echopype as ep
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import s3fs
+import xarray as xr
+from geopy.distance import distance
+
+from echodataflow.operations.operations_stratification import assign_stratum
+from echodataflow.utils.const import GRID_PARAMS
+
+
+@dataclass(frozen=True)
+class ReadNASCWorkItem:
+    """One NASC store to ingest."""
+
+    filename: str
+
+
+@dataclass(frozen=True)
+class ReadNASCSettings:
+    """Settings shared by a batch of NASC reads."""
+
+    filesystem: s3fs.S3FileSystem
+    input_directory: str
+    frequency_nominal: int = 38000
+
+
+def read_NASC(item: ReadNASCWorkItem, settings: ReadNASCSettings) -> pd.DataFrame:
+    """Read and normalize one NASC Zarr store."""
+    mapper = settings.filesystem.get_mapper(str(Path(settings.input_directory) / item.filename))
+    ds_NASC = xr.open_zarr(mapper, consolidated=True)
+    ds_NASC = ep.consolidate.swap_dims_channel_frequency(ds_NASC)
+
+    # Integrate over depth and retain the survey's primary acoustic frequency
+    df_NASC = ds_NASC.sum("depth").sel(frequency_nominal=settings.frequency_nominal).to_dataframe()
+    df_NASC["filename"] = item.filename
+    return df_NASC
+
+
+def read_accumulated_NASC(path: Path) -> pd.DataFrame:
+    """Read accumulated NASC data or return an empty dataframe on the first run."""
+    if not path.exists():
+        return pd.DataFrame()
+    return pd.read_csv(
+        path,
+        index_col=0,
+        date_format="ISO8601",
+        parse_dates=["ping_time"],
+    )
+
+
+def plan_NASC_ingestion(
+    available_filenames: list[str],
+    processed_filenames: list[str],
+    num_reprocess: int,
+    num_file_limit: int,
+) -> tuple[list[str], list[str]]:
+    """Select files to process and processed files whose rows should be replaced."""
+    if num_reprocess < 1:
+        raise ValueError("num_reprocess must be at least 1")
+    if num_file_limit < -1:
+        raise ValueError("file_limit must be -1 or non-negative")
+
+    available = set(available_filenames)
+    reprocess_candidates = [
+        filename for filename in processed_filenames[-num_reprocess:] if filename in available
+    ]
+    new_candidates = sorted(available.difference(processed_filenames))
+
+    # Prioritize explicitly requested reprocessing before previously unseen files
+    candidates = reprocess_candidates + [
+        filename for filename in new_candidates if filename not in reprocess_candidates
+    ]
+    selected = candidates if num_file_limit == -1 else candidates[:num_file_limit]
+    replacements = [filename for filename in reprocess_candidates if filename in selected]
+    return selected, replacements
+
+
+def write_NASC_outputs(
+    df_NASC: pd.DataFrame,
+    gdf_NASC: gpd.GeoDataFrame,
+    dataframe_path: Path,
+    grid_path: Path,
+) -> None:
+    """Stage and save integrated NASC CSV and GeoJSON outputs together."""
+    transaction_id = uuid4().hex
+    outputs = {
+        "dataframe": dataframe_path,
+        "grid": grid_path,
+    }
+    staged = {
+        key: path.with_name(f".{path.name}.{transaction_id}.tmp") for key, path in outputs.items()
+    }
+    backups: dict[str, Path] = {}
+    installed: list[str] = []
+
+    try:
+        # Finish both serializations before replacing either published output
+        for path in outputs.values():
+            path.parent.mkdir(parents=True, exist_ok=True)
+        df_NASC.to_csv(staged["dataframe"])
+        gdf_NASC.to_file(staged["grid"], driver="GeoJSON")
+
+        # Preserve existing outputs so publication can be rolled back
+        for key, target in outputs.items():
+            if target.exists():
+                backup = target.with_name(f".{target.name}.{transaction_id}.bak")
+                os.replace(target, backup)
+                backups[key] = backup
+            os.replace(staged[key], target)
+            installed.append(key)
+    except Exception:
+        rollback_errors = []
+        for key in reversed(installed):
+            try:
+                outputs[key].unlink(missing_ok=True)
+            except OSError as error:
+                rollback_errors.append(error)
+        for key, backup in backups.items():
+            try:
+                os.replace(backup, outputs[key])
+            except OSError as error:
+                rollback_errors.append(error)
+        if rollback_errors:
+            raise RuntimeError(
+                "Integration output update failed and could not be fully rolled back"
+            ) from rollback_errors[0]
+        raise
+    else:
+        for backup in backups.values():
+            backup.unlink(missing_ok=True)
+    finally:
+        for temporary in staged.values():
+            temporary.unlink(missing_ok=True)
+
+
+def add_biological_estimates(
+    df_NASC: pd.DataFrame,
+    df_stratum: pd.DataFrame,
+    reassign_strata: bool = True,
+) -> pd.DataFrame:
+    """Attach stratum estimates and derive number and biomass density."""
+    # Remove old estimates so updated haul biology can be merged without conflicts
+    result = df_NASC.drop(
+        ["sigma_bs_mean", "weight_mean"],
+        axis=1,
+        errors="ignore",
+    )
+    if reassign_strata:
+        result = result.drop("stratum", axis=1, errors="ignore")
+        result = assign_stratum(result, df_stratum)
+    result["stratum"] = result["stratum"].astype("Int64")
+    result = result.merge(
+        df_stratum[["stratum", "sigma_bs_mean", "weight_mean"]],
+        on="stratum",
+        how="left",
+    )
+
+    # Convert acoustic density to organism number and biomass density
+    result["number_density"] = result["NASC"] / result["sigma_bs_mean"]
+    result["biomass_density"] = result["number_density"] * result["weight_mean"]
+    return result
+
+
+def assign_NASC_to_grid(
+    df_stratum: pd.DataFrame,
+    df_NASC: pd.DataFrame,
+    utm_num: int,
+    gdf_boundary_utm: gpd.GeoDataFrame,
+) -> gpd.GeoDataFrame:
+    """Add projected coordinates, grid indices, and strata to NASC observations."""
+    # Convert NASC positions to the grid's UTM projection
+    gdf_NASC = gpd.GeoDataFrame(
+        data=df_NASC,
+        geometry=gpd.points_from_xy(df_NASC["longitude"], df_NASC["latitude"]),
+        crs=GRID_PARAMS["projection"],
+    ).to_crs(f"epsg:{utm_num}")
+
+    # Extract projected coordinates for grid binning
+    gdf_NASC["utm_x"] = gdf_NASC["geometry"].x
+    gdf_NASC["utm_y"] = gdf_NASC["geometry"].y
+
+    # Convert configured nautical-mile resolution to projected meter spacing
+    x_step = distance(nautical=GRID_PARAMS["resolution"]["x_distance"]).meters
+    y_step = distance(nautical=GRID_PARAMS["resolution"]["y_distance"]).meters
+    xmin, ymin, xmax, ymax = gdf_boundary_utm.total_bounds
+
+    # Bin longitude and latitude into numbered grid cells
+    x_bins = np.arange(xmin, xmax + x_step, x_step)
+    y_bins = np.arange(ymin, ymax + y_step, y_step)
+    gdf_NASC["grid_x"] = pd.cut(
+        gdf_NASC["utm_x"],
+        x_bins,
+        right=False,
+        labels=np.arange(1, len(x_bins)),
+    )
+    gdf_NASC["grid_y"] = pd.cut(
+        gdf_NASC["utm_y"],
+        y_bins,
+        right=True,
+        labels=np.arange(1, len(y_bins)),
+    )
+
+    # Add biological strata using observation latitude
+    return assign_stratum(gdf_NASC, df_stratum)
+
+
+def aggregate_NASC_to_grid(
+    gdf_NASC: gpd.GeoDataFrame,
+    gdf_grid_cells: gpd.GeoDataFrame,
+) -> gpd.GeoDataFrame:
+    """Aggregate NASC densities and derive abundance and biomass by grid cell."""
+    grid_cells = gdf_grid_cells.copy().set_index(["grid_x", "grid_y"])
+    grid_means = (
+        gdf_NASC.groupby(["grid_x", "grid_y"], observed=True)[
+            ["NASC", "number_density", "biomass_density"]
+        ]
+        .mean()
+        .reset_index()
+    )
+    grid_cells = grid_cells.merge(
+        grid_means,
+        on=["grid_x", "grid_y"],
+        how="left",
+    )
+
+    # Scale mean densities by cell area to obtain cell totals
+    grid_cells["abundance"] = grid_cells["number_density"] * grid_cells["area"]
+    grid_cells["biomass"] = grid_cells["biomass_density"] * grid_cells["area"]
+    return grid_cells

--- a/src/echodataflow/operations/operations_stratification.py
+++ b/src/echodataflow/operations/operations_stratification.py
@@ -1,0 +1,26 @@
+"""Shared survey stratification operations."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def assign_stratum(
+    dataframe: pd.DataFrame,
+    stratum_definitions: pd.DataFrame,
+) -> pd.DataFrame:
+    """Return a copy with strata assigned from each observation's latitude."""
+    result = dataframe.copy()
+
+    # Extend the configured northern limits to cover every possible latitude
+    latitude_bins = [-90.0] + stratum_definitions["latitude_northern_limit"].tolist() + [90.0]
+    stratum_labels = stratum_definitions["stratum"].tolist() + [
+        max(stratum_definitions["stratum"]) + 1
+    ]
+    result["stratum"] = pd.cut(
+        result["latitude"],
+        bins=latitude_bins,
+        labels=stratum_labels,
+        include_lowest=True,
+    )
+    return result

--- a/src/echodataflow/operations/operations_stratification.py
+++ b/src/echodataflow/operations/operations_stratification.py
@@ -12,11 +12,24 @@ def assign_stratum(
     """Return a copy with strata assigned from each observation's latitude."""
     result = dataframe.copy()
 
-    # Extend the configured northern limits to cover every possible latitude
-    latitude_bins = [-90.0] + stratum_definitions["latitude_northern_limit"].tolist() + [90.0]
-    stratum_labels = stratum_definitions["stratum"].tolist() + [
-        max(stratum_definitions["stratum"]) + 1
-    ]
+    # A missing northern limit denotes the final open-ended stratum
+    bounded = stratum_definitions.dropna(subset=["latitude_northern_limit"]).sort_values(
+        "latitude_northern_limit"
+    )
+    open_ended = stratum_definitions[stratum_definitions["latitude_northern_limit"].isna()]
+    if len(open_ended) > 1:
+        raise ValueError("Stratum definitions contain multiple open-ended strata")
+
+    northern_limits = bounded["latitude_northern_limit"].tolist()
+    if len(northern_limits) != len(set(northern_limits)):
+        raise ValueError("Stratum northern limits must be unique")
+
+    # Extend the configured limits to cover every possible latitude
+    latitude_bins = [-90.0, *northern_limits, 90.0]
+    final_stratum = (
+        open_ended["stratum"].iloc[0] if not open_ended.empty else bounded["stratum"].max() + 1
+    )
+    stratum_labels = [*bounded["stratum"].tolist(), final_stratum]
     result["stratum"] = pd.cut(
         result["latitude"],
         bins=latitude_bins,

--- a/src/echodataflow/tasks/tasks_integration.py
+++ b/src/echodataflow/tasks/tasks_integration.py
@@ -1,0 +1,19 @@
+"""Reusable Prefect tasks for acoustic-biological integration."""
+
+import pandas as pd
+from prefect import task
+
+from echodataflow.operations.operations_integration import (
+    ReadNASCSettings,
+    ReadNASCWorkItem,
+    read_NASC,
+)
+
+
+@task(log_prints=True)
+def task_read_NASC(
+    item: ReadNASCWorkItem,
+    settings: ReadNASCSettings,
+) -> pd.DataFrame:
+    """Read one NASC store within a Prefect task."""
+    return read_NASC(item, settings)

--- a/src/echodataflow/utils/grid.py
+++ b/src/echodataflow/utils/grid.py
@@ -136,7 +136,7 @@ def create_grid_cells(boundary_gdf_utm: gpd.GeoDataFrame, x_step: float, y_step:
             # Step forward
             x_coord.append(x_ct)
             y_coord.append(y_ct)
-            x1 = x0 - x_step
+            x1 = x0 + x_step
             y1 = y0 + y_step
             # Append to list
             grid_cells.append(sg.box(x0, y0, x1, y1))

--- a/src/echodataflow/utils/trawl_files.py
+++ b/src/echodataflow/utils/trawl_files.py
@@ -1,0 +1,50 @@
+"""Utilities for matching cloud trawl files to complete hauls."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+
+
+HAUL_NUMBER_PATTERN = re.compile(r"(?P<haul_num>\d{3})_[^_]+\.xlsx$", re.IGNORECASE)
+
+
+def get_valid_hauls(
+    bio_filenames: Mapping[str, Iterable[str]],
+) -> dict[int, dict[str, str]]:
+    """Return complete hauls mapped to their file paths by file type.
+
+    A haul is valid only when exactly one matching file exists for every file
+    type supplied in ``bio_filenames``. Files whose names do not end in a
+    three-digit haul number followed by an Excel filename suffix are ignored.
+    """
+    if not bio_filenames:
+        return {}
+
+    files_by_type: dict[str, dict[int, str]] = {}
+    for file_type, filenames in bio_filenames.items():
+        files_by_haul: dict[int, str] = {}
+        for filename in filenames:
+            match = HAUL_NUMBER_PATTERN.search(Path(filename).name)
+            if match is None:
+                continue
+
+            haul_num = int(match["haul_num"])
+            if haul_num in files_by_haul:
+                raise ValueError(
+                    f"Multiple {file_type!r} files found for haul {haul_num:03d}: "
+                    f"{files_by_haul[haul_num]!r} and {filename!r}"
+                )
+            files_by_haul[haul_num] = filename
+        files_by_type[file_type] = files_by_haul
+
+    valid_haul_numbers = set.intersection(
+        *(set(files_by_haul) for files_by_haul in files_by_type.values())
+    )
+    return {
+        haul_num: {
+            file_type: files_by_type[file_type][haul_num] for file_type in files_by_type
+        }
+        for haul_num in sorted(valid_haul_numbers)
+    }

--- a/src/echodataflow/utils/trawl_files.py
+++ b/src/echodataflow/utils/trawl_files.py
@@ -6,8 +6,18 @@ import re
 from collections.abc import Iterable, Mapping
 from pathlib import Path
 
-
 HAUL_NUMBER_PATTERN = re.compile(r"(?P<haul_num>\d{3})_[^_]+\.xlsx$", re.IGNORECASE)
+REQUIRED_TRAWL_FILE_TYPES = ("length", "specimen", "catch", "info")
+
+
+def discover_trawl_files(fs, path_bio_files: str) -> dict[str, list[str]]:
+    """Discover the four file types required for a complete trawl haul."""
+    return {
+        "length": fs.glob(f"{path_bio_files}/*/*_LFdata.xlsx"),
+        "specimen": fs.glob(f"{path_bio_files}/*/*_specimens.xlsx"),
+        "catch": fs.glob(f"{path_bio_files}/*/*_CatchPerc.xlsx"),
+        "info": fs.glob(f"{path_bio_files}/*/*_NetConfig.xlsx"),
+    }
 
 
 def get_valid_hauls(
@@ -21,6 +31,10 @@ def get_valid_hauls(
     """
     if not bio_filenames:
         return {}
+
+    missing_types = set(REQUIRED_TRAWL_FILE_TYPES).difference(bio_filenames)
+    if missing_types:
+        raise ValueError(f"Missing required trawl file types: {sorted(missing_types)}")
 
     files_by_type: dict[str, dict[int, str]] = {}
     for file_type, filenames in bio_filenames.items():
@@ -43,8 +57,6 @@ def get_valid_hauls(
         *(set(files_by_haul) for files_by_haul in files_by_type.values())
     )
     return {
-        haul_num: {
-            file_type: files_by_type[file_type][haul_num] for file_type in files_by_type
-        }
+        haul_num: {file_type: files_by_type[file_type][haul_num] for file_type in files_by_type}
         for haul_num in sorted(valid_haul_numbers)
     }

--- a/tests/test_flow_raw2sv.py
+++ b/tests/test_flow_raw2sv.py
@@ -1,6 +1,10 @@
 import pytest
 from types import SimpleNamespace
 
+pytestmark = pytest.mark.skip(
+    reason="Temporarily disabled while flows_acoustics.py is reverted to 3c1b9d3"
+)
+
 from echodataflow.flows import flows_acoustics
 
 

--- a/tests/test_flow_simulate_transects.py
+++ b/tests/test_flow_simulate_transects.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from echodataflow.flows import flows_simulation
 
@@ -16,6 +17,9 @@ class FakeVariable:
         cls.stored[key] = value
 
 
+@pytest.mark.filterwarnings(
+    "error:The behavior of DataFrame concatenation with empty or all-NA entries:FutureWarning"
+)
 def test_flow_simulate_transects_opens_closes_and_advances(monkeypatch, tmp_path):
     FakeVariable.stored = {}
     monkeypatch.setattr(flows_simulation, "Variable", FakeVariable)

--- a/tests/test_flows_integration.py
+++ b/tests/test_flows_integration.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+
+from echodataflow.flows import flows_integration
+
+
+def test_flow_ingest_NASC_waits_for_stratum_estimates(monkeypatch, tmp_path):
+    messages = []
+    monkeypatch.setattr(
+        flows_integration,
+        "get_run_logger",
+        lambda: SimpleNamespace(info=messages.append),
+    )
+    monkeypatch.setattr(
+        flows_integration.s3fs,
+        "S3FileSystem",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("S3 should not be accessed")),
+    )
+
+    result = flows_integration.flow_ingest_NASC.fn(path_vm_local=str(tmp_path))
+
+    assert result is None
+    assert messages == [
+        f"Upstream stratum estimates are not ready: {tmp_path / 'stratum_mean.csv'}"
+    ]
+
+
+def test_flow_update_grid_waits_for_all_upstream_inputs(monkeypatch, tmp_path):
+    messages = []
+    monkeypatch.setattr(
+        flows_integration,
+        "get_run_logger",
+        lambda: SimpleNamespace(info=messages.append),
+    )
+    monkeypatch.setattr(
+        flows_integration.gpd,
+        "read_file",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("GeoJSON should not be read")
+        ),
+    )
+
+    result = flows_integration.flow_update_grid.fn(path_vm_local=str(tmp_path))
+
+    assert result is None
+    assert len(messages) == 1
+    assert "NASC_all_griddify.geojson" in messages[0]
+    assert "stratum_mean.csv" in messages[0]

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,0 +1,18 @@
+import geopandas as gpd
+from shapely.geometry import Point
+
+from echodataflow.utils.grid import create_grid_cells
+
+
+def test_create_grid_cells_extends_eastward_from_boundary_minimum():
+    boundary = gpd.GeoDataFrame(
+        geometry=[Point(0, 0), Point(20, 10)],
+        crs="EPSG:32610",
+    )
+
+    cells = create_grid_cells(boundary, x_step=10, y_step=10)
+
+    assert cells.iloc[0]["grid_x"] == 1
+    assert cells.iloc[0]["grid_y"] == 1
+    assert cells.iloc[0].geometry.bounds == (0.0, 0.0, 10.0, 10.0)
+    assert cells.iloc[1].geometry.bounds == (10.0, 0.0, 20.0, 10.0)

--- a/tests/test_operations_biology.py
+++ b/tests/test_operations_biology.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+import pandas as pd
+import pandas.testing as pdt
+
+from echodataflow.operations.operations_biology import (
+    BiologyData,
+    add_stratum,
+    combine_biology_data,
+    get_count_from_length_specimen,
+    get_hauls_to_process,
+    read_biology_data,
+    write_biology_outputs,
+)
+
+
+def _biology_data(haul: int) -> BiologyData:
+    location = {"haul": haul, "latitude": 40.0}
+    return BiologyData(
+        haul_info=pd.DataFrame([location]),
+        specimens=pd.DataFrame([{**location, "length": 10}]),
+        lengths=pd.DataFrame([{**location, "length": 10}]),
+        length_counts=pd.DataFrame([{**location, "length": 10, "frequency": 1}]),
+    )
+
+
+def _output_paths(directory: Path) -> dict[str, Path]:
+    return {
+        "haul_info": directory / "haul_info.csv",
+        "specimens": directory / "specimens.csv",
+        "lengths": directory / "lengths.csv",
+        "length_counts": directory / "length_counts.csv",
+    }
+
+
+def test_get_hauls_to_process_returns_sorted_unprocessed_hauls():
+    valid = {3: {}, 1: {}, 2: {}}
+    haul_info = pd.DataFrame({"haul": [2]})
+
+    assert get_hauls_to_process(valid, haul_info) == [1, 3]
+
+
+def test_count_and_stratum_operations_do_not_mutate_inputs():
+    lengths = pd.DataFrame({"sex": ["female"], "length": [10], "haul": [1], "frequency": [2]})
+    specimens = pd.DataFrame({"sex": ["female"], "fork_length": [10.2], "haul": [1]})
+    original_specimens = specimens.copy()
+    strata = pd.DataFrame({"stratum": [1], "latitude_northern_limit": [45.0]})
+    located = pd.DataFrame({"latitude": [40.0]})
+    original_located = located.copy()
+
+    counts = get_count_from_length_specimen(lengths, specimens)
+    stratified = add_stratum(located, strata)
+
+    assert counts.iloc[0]["frequency"] == 3
+    pdt.assert_frame_equal(specimens, original_specimens)
+    pdt.assert_frame_equal(located, original_located)
+    assert "stratum" in stratified
+
+
+def test_combine_biology_data_combines_each_dataframe():
+    combined = combine_biology_data([_biology_data(1), _biology_data(2)])
+
+    assert combined.haul_info["haul"].tolist() == [1, 2]
+    assert combined.specimens["haul"].tolist() == [1, 2]
+    assert combined.lengths["haul"].tolist() == [1, 2]
+    assert combined.length_counts["haul"].tolist() == [1, 2]
+
+
+def test_write_biology_outputs_publishes_all_outputs(tmp_path):
+    paths = _output_paths(tmp_path)
+    stratum_path = tmp_path / "stratum_mean.csv"
+    data = _biology_data(1)
+    stratum_mean = pd.DataFrame({"stratum": [1], "weight_mean": [2.5]})
+
+    write_biology_outputs(data, stratum_mean, paths, stratum_path)
+    loaded = read_biology_data(paths)
+
+    pdt.assert_frame_equal(loaded.haul_info, data.haul_info)
+    pdt.assert_frame_equal(loaded.specimens, data.specimens)
+    pdt.assert_frame_equal(loaded.lengths, data.lengths)
+    pdt.assert_frame_equal(loaded.length_counts, data.length_counts)
+    pdt.assert_frame_equal(pd.read_csv(stratum_path, index_col=0), stratum_mean)
+    assert not list(tmp_path.glob(".*.tmp"))
+    assert not list(tmp_path.glob(".*.bak"))

--- a/tests/test_operations_biology.py
+++ b/tests/test_operations_biology.py
@@ -5,7 +5,6 @@ import pandas.testing as pdt
 
 from echodataflow.operations.operations_biology import (
     BiologyData,
-    add_stratum,
     combine_biology_data,
     get_count_from_length_specimen,
     get_hauls_to_process,
@@ -41,21 +40,14 @@ def test_get_hauls_to_process_returns_sorted_unprocessed_hauls():
     assert get_hauls_to_process(valid, haul_info) == [1, 3]
 
 
-def test_count_and_stratum_operations_do_not_mutate_inputs():
+def test_count_operation_does_not_mutate_specimens():
     lengths = pd.DataFrame({"sex": ["female"], "length": [10], "haul": [1], "frequency": [2]})
     specimens = pd.DataFrame({"sex": ["female"], "fork_length": [10.2], "haul": [1]})
     original_specimens = specimens.copy()
-    strata = pd.DataFrame({"stratum": [1], "latitude_northern_limit": [45.0]})
-    located = pd.DataFrame({"latitude": [40.0]})
-    original_located = located.copy()
-
     counts = get_count_from_length_specimen(lengths, specimens)
-    stratified = add_stratum(located, strata)
 
     assert counts.iloc[0]["frequency"] == 3
     pdt.assert_frame_equal(specimens, original_specimens)
-    pdt.assert_frame_equal(located, original_located)
-    assert "stratum" in stratified
 
 
 def test_combine_biology_data_combines_each_dataframe():

--- a/tests/test_operations_biology.py
+++ b/tests/test_operations_biology.py
@@ -9,6 +9,7 @@ from echodataflow.operations.operations_biology import (
     combine_biology_data,
     get_count_from_length_specimen,
     get_hauls_to_process,
+    get_length_weight_regression,
     read_biology_data,
     write_biology_outputs,
 )
@@ -64,6 +65,23 @@ def test_combine_biology_data_combines_each_dataframe():
     assert combined.specimens["haul"].tolist() == [1, 2]
     assert combined.lengths["haul"].tolist() == [1, 2]
     assert combined.length_counts["haul"].tolist() == [1, 2]
+
+
+def test_length_weight_regression_ignores_unobserved_strata():
+    specimens = pd.DataFrame(
+        {
+            "sex": ["Female", "Female", "Male", "Male"],
+            "stratum": pd.Categorical([1, 1, 2, 2], categories=[1, 2, 3]),
+            "length": [10, 20, 12, 24],
+            "organism_weight": [5, 20, 7, 28],
+        }
+    )
+
+    regression = get_length_weight_regression(specimens)
+
+    assert set(regression["stratum"]) == {1, 2}
+    assert set(regression["sex"]) == {"female", "male", "all"}
+    assert len(regression) == 4
 
 
 def test_write_biology_outputs_publishes_all_outputs(tmp_path):

--- a/tests/test_operations_integration.py
+++ b/tests/test_operations_integration.py
@@ -1,0 +1,229 @@
+from pathlib import Path
+
+import geopandas as gpd
+import pandas as pd
+import pandas.testing as pdt
+from shapely.geometry import Point
+
+from echodataflow.operations import operations_integration
+from echodataflow.utils.const import GRID_PARAMS
+from echodataflow.utils.grid import create_boundary_gdf
+
+
+class FakeFileSystem:
+    def get_mapper(self, path):
+        return path
+
+
+class FakeNASCDataset:
+    def __init__(self):
+        self.selection = None
+
+    def sum(self, dimension):
+        assert dimension == "depth"
+        return self
+
+    def sel(self, **selection):
+        self.selection = selection
+        return self
+
+    def to_dataframe(self):
+        return pd.DataFrame({"NASC": [1.0]})
+
+
+def test_read_NASC_returns_dataframe_with_source_filename(monkeypatch):
+    dataset = FakeNASCDataset()
+    monkeypatch.setattr(
+        operations_integration.xr,
+        "open_zarr",
+        lambda mapper, consolidated: dataset,
+    )
+    monkeypatch.setattr(
+        operations_integration.ep.consolidate,
+        "swap_dims_channel_frequency",
+        lambda value: value,
+    )
+    settings = operations_integration.ReadNASCSettings(
+        filesystem=FakeFileSystem(),
+        input_directory="bucket/nasc",
+        frequency_nominal=120000,
+    )
+
+    result = operations_integration.read_NASC(
+        operations_integration.ReadNASCWorkItem(filename="first.zarr"),
+        settings,
+    )
+
+    assert result["filename"].tolist() == ["first.zarr"]
+    assert dataset.selection == {"frequency_nominal": 120000}
+
+
+def test_plan_NASC_ingestion_prioritizes_reprocessing_within_limit():
+    selected, replacements = operations_integration.plan_NASC_ingestion(
+        available_filenames=["001.zarr", "002.zarr", "003.zarr", "004.zarr"],
+        processed_filenames=["001.zarr", "002.zarr", "003.zarr"],
+        num_reprocess=2,
+        num_file_limit=2,
+    )
+
+    assert selected == ["002.zarr", "003.zarr"]
+    assert replacements == ["002.zarr", "003.zarr"]
+
+
+def test_plan_NASC_ingestion_replaces_only_selected_reprocessing_files():
+    selected, replacements = operations_integration.plan_NASC_ingestion(
+        available_filenames=["001.zarr", "002.zarr", "003.zarr", "004.zarr"],
+        processed_filenames=["001.zarr", "002.zarr", "003.zarr"],
+        num_reprocess=2,
+        num_file_limit=1,
+    )
+
+    assert selected == ["002.zarr"]
+    assert replacements == ["002.zarr"]
+
+
+def test_integration_outputs_round_trip(tmp_path):
+    dataframe_path = tmp_path / "NASC_all.csv"
+    grid_path = tmp_path / "NASC_grid.geojson"
+    expected = pd.DataFrame(
+        {
+            "ping_time": pd.to_datetime(["2026-01-01T00:00:00"]),
+            "NASC": [1.0],
+        }
+    )
+    expected_grid = gpd.GeoDataFrame(
+        {"NASC": [1.0]},
+        geometry=[Point(-125.0, 40.0)],
+        crs="EPSG:4326",
+    )
+
+    operations_integration.write_NASC_outputs(
+        expected,
+        expected_grid,
+        dataframe_path,
+        grid_path,
+    )
+    result = operations_integration.read_accumulated_NASC(dataframe_path)
+    result_grid = gpd.read_file(grid_path)
+
+    pdt.assert_frame_equal(result, expected)
+    assert result_grid["NASC"].tolist() == [1.0]
+    assert not list(tmp_path.glob(".*.tmp"))
+    assert not list(tmp_path.glob(".*.bak"))
+
+
+def test_integration_outputs_restore_both_outputs_on_publish_failure(tmp_path, monkeypatch):
+    dataframe_path = tmp_path / "NASC_all.csv"
+    grid_path = tmp_path / "NASC_grid.geojson"
+    original = pd.DataFrame({"ping_time": ["2026-01-01"], "NASC": [1.0]})
+    replacement = pd.DataFrame({"ping_time": ["2026-01-02"], "NASC": [2.0]})
+    original_grid = gpd.GeoDataFrame(
+        {"NASC": [1.0]}, geometry=[Point(-125.0, 40.0)], crs="EPSG:4326"
+    )
+    replacement_grid = gpd.GeoDataFrame(
+        {"NASC": [2.0]}, geometry=[Point(-124.0, 41.0)], crs="EPSG:4326"
+    )
+    operations_integration.write_NASC_outputs(
+        original, original_grid, dataframe_path, grid_path
+    )
+
+    real_replace = operations_integration.os.replace
+    failed = False
+
+    def fail_grid_publication(source, destination):
+        nonlocal failed
+        source = Path(source)
+        destination = Path(destination)
+        if not failed and source.suffix == ".tmp" and destination == grid_path:
+            failed = True
+            raise OSError("publish failed")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(operations_integration.os, "replace", fail_grid_publication)
+
+    try:
+        operations_integration.write_NASC_outputs(
+            replacement,
+            replacement_grid,
+            dataframe_path,
+            grid_path,
+        )
+    except OSError as error:
+        assert str(error) == "publish failed"
+    else:
+        raise AssertionError("Expected grid publication to fail")
+
+    assert pd.read_csv(dataframe_path, index_col=0)["NASC"].tolist() == [1.0]
+    assert gpd.read_file(grid_path)["NASC"].tolist() == [1.0]
+
+
+def test_add_biological_estimates_replaces_previous_values():
+    nasc = pd.DataFrame(
+        {
+            "latitude": [40.0],
+            "NASC": [20.0],
+            "stratum": [99],
+            "sigma_bs_mean": [999.0],
+            "weight_mean": [999.0],
+        }
+    )
+    strata = pd.DataFrame(
+        {
+            "stratum": [1],
+            "latitude_northern_limit": [45.0],
+            "sigma_bs_mean": [2.0],
+            "weight_mean": [3.0],
+        }
+    )
+
+    result = operations_integration.add_biological_estimates(nasc, strata)
+
+    assert result.iloc[0]["stratum"] == 1
+    assert result.iloc[0]["number_density"] == 10.0
+    assert result.iloc[0]["biomass_density"] == 30.0
+
+
+def test_assign_NASC_to_grid_assigns_grid_coordinates_and_strata():
+    _, boundary_utm, utm_num = create_boundary_gdf(
+        bounds=GRID_PARAMS["bounds"],
+        projection=GRID_PARAMS["projection"],
+    )
+    nasc = pd.DataFrame({"longitude": [-125.0], "latitude": [40.0], "NASC": [1.0]})
+    strata = pd.DataFrame(
+        {
+            "stratum": [1, 2],
+            "latitude_northern_limit": [45.0, 50.0],
+        }
+    )
+
+    gridded = operations_integration.assign_NASC_to_grid(
+        strata,
+        nasc,
+        utm_num,
+        boundary_utm,
+    )
+
+    assert gridded["grid_x"].notna().all()
+    assert gridded["grid_y"].notna().all()
+    assert gridded["stratum"].astype(int).tolist() == [1]
+
+
+def test_aggregate_NASC_to_grid_computes_cell_means_and_totals():
+    observations = gpd.GeoDataFrame(
+        {
+            "grid_x": [1, 1],
+            "grid_y": [2, 2],
+            "NASC": [10.0, 30.0],
+            "number_density": [2.0, 6.0],
+            "biomass_density": [4.0, 12.0],
+        }
+    )
+    cells = gpd.GeoDataFrame({"grid_x": [1], "grid_y": [2], "area": [5.0]})
+
+    result = operations_integration.aggregate_NASC_to_grid(observations, cells)
+
+    assert result.iloc[0]["NASC"] == 20.0
+    assert result.iloc[0]["number_density"] == 4.0
+    assert result.iloc[0]["biomass_density"] == 8.0
+    assert result.iloc[0]["abundance"] == 20.0
+    assert result.iloc[0]["biomass"] == 40.0

--- a/tests/test_operations_stratification.py
+++ b/tests/test_operations_stratification.py
@@ -18,3 +18,17 @@ def test_assign_stratum_returns_copy_with_latitude_based_strata():
 
     pdt.assert_frame_equal(observations, original)
     assert result["stratum"].astype(int).tolist() == [1, 1, 2, 3]
+
+
+def test_assign_stratum_supports_unsorted_open_ended_stratum():
+    observations = pd.DataFrame({"latitude": [35.0, 40.0, 50.0, 60.0]})
+    definitions = pd.DataFrame(
+        {
+            "stratum": [7, 3, 1, 6],
+            "latitude_northern_limit": [None, 43.0, 36.0, 55.0],
+        }
+    )
+
+    result = assign_stratum(observations, definitions)
+
+    assert result["stratum"].astype(int).tolist() == [1, 3, 6, 7]

--- a/tests/test_operations_stratification.py
+++ b/tests/test_operations_stratification.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import pandas.testing as pdt
+
+from echodataflow.operations.operations_stratification import assign_stratum
+
+
+def test_assign_stratum_returns_copy_with_latitude_based_strata():
+    observations = pd.DataFrame({"latitude": [-90.0, 40.0, 50.0, 90.0]})
+    original = observations.copy()
+    definitions = pd.DataFrame(
+        {
+            "stratum": [1, 2],
+            "latitude_northern_limit": [45.0, 55.0],
+        }
+    )
+
+    result = assign_stratum(observations, definitions)
+
+    pdt.assert_frame_equal(observations, original)
+    assert result["stratum"].astype(int).tolist() == [1, 1, 2, 3]

--- a/tests/test_tasks_integration.py
+++ b/tests/test_tasks_integration.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+from echodataflow.tasks import tasks_integration
+
+
+def test_read_NASC_task_delegates_to_operation(monkeypatch):
+    expected = pd.DataFrame({"NASC": [1.0]})
+    calls = {}
+
+    def fake_read(item, settings):
+        calls["arguments"] = (item, settings)
+        return expected
+
+    monkeypatch.setattr(tasks_integration, "read_NASC", fake_read)
+    item = object()
+    settings = object()
+
+    result = tasks_integration.task_read_NASC.fn(item, settings)
+
+    assert result is expected
+    assert calls["arguments"] == (item, settings)

--- a/tests/test_trawl_files.py
+++ b/tests/test_trawl_files.py
@@ -1,6 +1,6 @@
 import pytest
 
-from echodataflow.utils.trawl_files import get_valid_hauls
+from echodataflow.utils.trawl_files import discover_trawl_files, get_valid_hauls
 
 
 def test_get_valid_hauls_returns_complete_file_mapping():
@@ -27,9 +27,37 @@ def test_get_valid_hauls_rejects_duplicate_file_type_for_haul():
             {
                 "length": ["first/001_LFdata.xlsx", "second/001_LFdata.xlsx"],
                 "specimen": ["001_specimens.xlsx"],
+                "catch": ["001_CatchPerc.xlsx"],
+                "info": ["001_NetConfig.xlsx"],
             }
         )
 
 
 def test_get_valid_hauls_handles_empty_inventory():
     assert get_valid_hauls({}) == {}
+
+
+def test_get_valid_hauls_requires_all_file_types():
+    with pytest.raises(ValueError, match="Missing required trawl file types"):
+        get_valid_hauls({"length": []})
+
+
+def test_discover_trawl_files_uses_expected_patterns():
+    class FileSystem:
+        def __init__(self):
+            self.patterns = []
+
+        def glob(self, pattern):
+            self.patterns.append(pattern)
+            return [pattern]
+
+    fs = FileSystem()
+    discovered = discover_trawl_files(fs, "bucket/trawls")
+
+    assert set(discovered) == {"length", "specimen", "catch", "info"}
+    assert fs.patterns == [
+        "bucket/trawls/*/*_LFdata.xlsx",
+        "bucket/trawls/*/*_specimens.xlsx",
+        "bucket/trawls/*/*_CatchPerc.xlsx",
+        "bucket/trawls/*/*_NetConfig.xlsx",
+    ]

--- a/tests/test_trawl_files.py
+++ b/tests/test_trawl_files.py
@@ -1,0 +1,35 @@
+import pytest
+
+from echodataflow.utils.trawl_files import get_valid_hauls
+
+
+def test_get_valid_hauls_returns_complete_file_mapping():
+    bio_filenames = {
+        "length": ["bucket/LengthFreq/001_LFdata.xlsx", "bucket/LengthFreq/002_LFdata.xlsx"],
+        "specimen": ["bucket/Specimens/001_specimens.xlsx"],
+        "catch": ["bucket/Catch/001_CatchPerc.xlsx"],
+        "info": ["bucket/NetConfig/202506_001_NetConfig.xlsx"],
+    }
+
+    assert get_valid_hauls(bio_filenames) == {
+        1: {
+            "length": "bucket/LengthFreq/001_LFdata.xlsx",
+            "specimen": "bucket/Specimens/001_specimens.xlsx",
+            "catch": "bucket/Catch/001_CatchPerc.xlsx",
+            "info": "bucket/NetConfig/202506_001_NetConfig.xlsx",
+        }
+    }
+
+
+def test_get_valid_hauls_rejects_duplicate_file_type_for_haul():
+    with pytest.raises(ValueError, match="Multiple 'length' files found for haul 001"):
+        get_valid_hauls(
+            {
+                "length": ["first/001_LFdata.xlsx", "second/001_LFdata.xlsx"],
+                "specimen": ["001_specimens.xlsx"],
+            }
+        )
+
+
+def test_get_valid_hauls_handles_empty_inventory():
+    assert get_valid_hauls({}) == {}


### PR DESCRIPTION
This PR refactors the cloud integration flows to use the new repo structure by splitting functions into `flows`, `tasks`, `opertaions`, and `utils`.

Note this PR also reverted changed made in #179 (which was to use database ledger for the real-time raw2Sv flow) -- it was only a partial migration and all downstream flows still use CSV files, which is messy. I think it's better to just do the database ledger update for all flows at once. @LOCEANlloydizard and I agreed on not touching the CPS flows though, which currently uses the raw2Sv database ledger.