### PR TITLE
Remove use of `deployment_already_running`

### DIFF
--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -10,11 +10,10 @@ import echopype as ep
 
 from prefect import flow, get_run_logger, get_client
 from prefect.futures import as_completed
-from prefect.states import Cancelled, Failed
+from prefect.states import Failed
 from prefect import runtime
 from prefect.events import emit_event
 
-from echodataflow.flows.flows_helper import deployment_already_running
 from echodataflow.deployment.task_runners import dask_task_runner_from_environment
 from echodataflow.utils.manifests import (
     MVBS_COLUMNS_POSTPROCESSING,
@@ -76,20 +75,6 @@ def flow_raw2Sv(
     add_location: bool = True,
     add_splitbeam_angle: bool = False,
 ):
-
-    # Check if the deployment is already running
-    already_running = asyncio.run(deployment_already_running())
-    if already_running:
-
-        async def cancel_run():
-            async with get_client() as client:
-                await client.set_flow_run_state(
-                    flow_run_id=runtime.flow_run.id,
-                    state=Cancelled(message="Another instance of this flow is already running"),
-                )
-
-        asyncio.run(cancel_run())
-        return  # exit the flow early
 
     # Assemble paths
     path_Sv_zarr = Path(path_main) / "Sv"

--- a/tests/test_flow_raw2Sv.py
+++ b/tests/test_flow_raw2Sv.py
@@ -8,10 +8,6 @@ pytestmark = pytest.mark.skip(
 from echodataflow.flows import flows_acoustics
 
 
-async def _false_async():
-    return False
-
-
 def test_flow_raw2sv_uses_processing_ledger(monkeypatch, tmp_path):
     raw_file = tmp_path / "example.raw"
 
@@ -19,12 +15,6 @@ def test_flow_raw2sv_uses_processing_ledger(monkeypatch, tmp_path):
         "processing": [],
         "completed": [],
     }
-
-    monkeypatch.setattr(
-        flows_acoustics,
-        "deployment_already_running",
-        lambda: _false_async(),
-    )
 
     monkeypatch.setattr(
         flows_acoustics,
@@ -97,12 +87,6 @@ def test_flow_raw2sv_marks_failed(monkeypatch, tmp_path):
     calls = {
         "failed": [],
     }
-
-    monkeypatch.setattr(
-        flows_acoustics,
-        "deployment_already_running",
-        lambda: _false_async(),
-    )
 
     monkeypatch.setattr(
         flows_acoustics,


### PR DESCRIPTION
This PR removes the use of `deployment_already_running` from the near real-time `flow_raw2Sv` since in the latest version of deployment engine that is handled through recipe specification through `deployment_concurrency` under each flow.

@LOCEANlloydizard @eliascapriles-NOAA - pinging you noth here because I have reverted this once but that got overwritten again when #153 was merged. It'll cleaner if you could do a quick patch to the CPS flows/recipe after @eliascapriles-NOAA finishes up all the downstream work of the workflow (e.g. creating Echoview-compatible NASC files).

The yaml specification looks like:
```yaml
  raw2Sv:
    deployment_name: raw2Sv
    deployment_concurrency:
      limit: 1
      collision_strategy: CANCEL_NEW
    interval: 5
```
