### PR TITLE
Remove event emission from `flow_raw2Sv`

### DIFF
--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -12,7 +12,6 @@ from prefect import flow, get_run_logger, get_client
 from prefect.futures import as_completed
 from prefect.states import Failed
 from prefect import runtime
-from prefect.events import emit_event
 
 from echodataflow.deployment.task_runners import dask_task_runner_from_environment
 from echodataflow.utils.manifests import (
@@ -227,15 +226,6 @@ def flow_raw2Sv(
 
         asyncio.run(set_failed_state())
         raise Exception(error_msg)
-
-    emit_event(
-        event="echodataflow.sv.updated",
-        resource={
-            "prefect.resource.id": "sv-monitor",
-            "prefect.resource.name": "sv-monitor",
-        },
-    )
-
 
 @flow(log_prints=True)
 async def flow_create_MVBS(

--- a/tests/deployment/test_deploy_engine.py
+++ b/tests/deployment/test_deploy_engine.py
@@ -124,23 +124,23 @@ def test_build_deploy_specs_passes_target_flow_parameters_directly(install_prefe
     engine = importlib.import_module("echodataflow.deployment.deployment_engine")
 
     specs = engine.build_deploy_specs(
-        param_cfg={"flows": {"emit_event_ABC": {"msg": "hello"}}},
+        param_cfg={"flows": {"raw2Sv": {"path_main": "/data"}}},
         deploy_cfg={
             "flows": {
-                "emit_event_ABC": {
+                "raw2Sv": {
                     "interval": 1,
                 }
             }
         },
         resolved_flows={
-            "emit_event_ABC": {
+            "raw2Sv": {
                 "flow_obj": object(),
-                "entrypoint": "echodataflow/flows/flows_test.py:flow_emit_event_ABC",
+                "entrypoint": "echodataflow/flows/flows_acoustics.py:flow_raw2Sv",
             }
         },
     )
 
-    assert specs[0].parameters == {"msg": "hello"}
+    assert specs[0].parameters == {"path_main": "/data"}
 
 
 def test_build_deploy_specs_preserves_runner_and_concurrency_group(install_prefect_stubs):


### PR DESCRIPTION
This PR follows from #184 to clean up regression remnants so that no flow emits additional custom events just to signal execution completion, since we've updated the codebase to use prefect's default events for flow execution completion.