### PR TITLE
Standardize timezone handling by converting all timestamps to UTC

### DIFF
--- a/src/echodataflow/flows/flows_acoustics.py
+++ b/src/echodataflow/flows/flows_acoustics.py
@@ -106,7 +106,7 @@ def flow_raw2Sv(
                 filename.name
                 for filename in path_raw.glob(filename_pattern)
                 if extract_datetime_from_filename(filename.name)
-                >= datetime.datetime.fromisoformat(exclude_before)
+                >= pd.to_datetime(exclude_before, utc=True)
             ]
         )
 
@@ -331,8 +331,8 @@ async def flow_create_MVBS(
         # Get Sv files in the specified time range
         Sv_filenames = sorted(
             df_Sv[
-                (pd.to_datetime(df_Sv["last_ping_time"]) >= start_time[snum])
-                & (pd.to_datetime(df_Sv["first_ping_time"]) <= end_time[snum])
+                (pd.to_datetime(df_Sv["last_ping_time"], utc=True) >= start_time[snum])
+                & (pd.to_datetime(df_Sv["first_ping_time"], utc=True) <= end_time[snum])
             ]["Sv_filename"].tolist()
         )
         logger.info(
@@ -381,8 +381,8 @@ async def flow_create_MVBS(
             idx_to_add = len(df_MVBS)
         df_MVBS.loc[idx_to_add] = [
             result.mvbs_filename,
-            result.first_ping_time,
-            result.last_ping_time,
+            pd.to_datetime(result.first_ping_time, utc=True),
+            pd.to_datetime(result.last_ping_time, utc=True),
         ]
 
     # Save updated MVBS info dataframe
@@ -499,8 +499,8 @@ def flow_raw2Sv_postprocessing(
                 result.filename_raw,
                 result.filename_Sv,
                 "completed",
-                result.first_ping_time,
-                result.last_ping_time,
+                pd.to_datetime(result.first_ping_time, utc=True),
+                pd.to_datetime(result.last_ping_time, utc=True),
                 "",
             ]
             write_manifest(df_Sv, file_Sv_csv)
@@ -600,8 +600,8 @@ def flow_create_MVBS_postprocessing(
                 ],
             ] = [
                 result.mvbs_filename,
-                result.first_ping_time,
-                result.last_ping_time,
+                pd.to_datetime(result.first_ping_time, utc=True),
+                pd.to_datetime(result.last_ping_time, utc=True),
                 item.is_partial,
                 "completed",
                 "",

--- a/src/echodataflow/flows/flows_predict_hake.py
+++ b/src/echodataflow/flows/flows_predict_hake.py
@@ -161,8 +161,8 @@ async def flow_predict_hake(
         # Get MVBS files in the specified time range
         MVBS_filenames = sorted(
             df_MVBS[
-                (pd.to_datetime(df_MVBS["last_ping_time"]) >= start_time[snum])
-                & (pd.to_datetime(df_MVBS["first_ping_time"]) < end_time[snum])
+                (pd.to_datetime(df_MVBS["last_ping_time"], utc=True) >= start_time[snum])
+                & (pd.to_datetime(df_MVBS["first_ping_time"], utc=True) < end_time[snum])
             ]["MVBS_filename"].tolist()
         )
         logger.info(
@@ -227,8 +227,8 @@ async def flow_predict_hake(
                 prediction_result.softmax_filename,
                 prediction_result.prediction_filename,
                 prediction_result.evr_filename,
-                prediction_result.first_ping_time,
-                prediction_result.last_ping_time,
+                pd.to_datetime(prediction_result.first_ping_time, utc=True),
+                pd.to_datetime(prediction_result.last_ping_time, utc=True),
             ]
         except Exception as e:
             errors.append(e)
@@ -352,8 +352,8 @@ def flow_predict_hake_postprocessing(
                 result.softmax_filename,
                 result.prediction_filename,
                 result.evr_filename,
-                result.first_ping_time,
-                result.last_ping_time,
+                pd.to_datetime(result.first_ping_time, utc=True),
+                pd.to_datetime(result.last_ping_time, utc=True),
                 "completed",
                 "",
             ]

--- a/src/echodataflow/flows/flows_simulation.py
+++ b/src/echodataflow/flows/flows_simulation.py
@@ -47,13 +47,11 @@ def flow_copy_raw(
     print("Copy raw files to simulate data generation")
     print(f"Executed at {datetime.datetime.now(datetime.UTC)}")
 
-    df_raw = pd.read_csv(
-        path_raw_list,
-        date_format="ISO8601",
-        parse_dates=["timestamp"],
+    df_raw = pd.read_csv(path_raw_list)
+    # Accept legacy naive values and offset-qualified values in the same file
+    df_raw["timestamp"] = pd.to_datetime(
+        df_raw["timestamp"], format="mixed", utc=True
     )
-    if df_raw["timestamp"].dt.tz is None:
-        df_raw["timestamp"] = df_raw["timestamp"].dt.tz_localize("UTC")
 
     # Set flow execution time to current time - time_offset_seconds
     flow_time_curr = (

--- a/src/echodataflow/flows/flows_viz_cloud.py
+++ b/src/echodataflow/flows/flows_viz_cloud.py
@@ -59,7 +59,7 @@ def flow_update_cache_MVBS(
             index_col=0,
         )
 
-    # Accept legacy naive values and offset-qualified values in the same file.
+    # Accept legacy naive values and offset-qualified values in the same file
     if not df_MVBS.empty:
         for column in ["first_ping_time", "last_ping_time"]:
             df_MVBS[column] = pd.to_datetime(

--- a/src/echodataflow/flows/flows_viz_cloud.py
+++ b/src/echodataflow/flows/flows_viz_cloud.py
@@ -56,22 +56,21 @@ def flow_update_cache_MVBS(
     with fs.open(str(Path(path_MVBS).parent / file_MVBS_csv), "r") as f:
         df_MVBS = pd.read_csv(
             f,
-            parse_dates=["first_ping_time", "last_ping_time"],
             index_col=0,
         )
 
-    # Convert last_ping_time and first_ping_time to UTC
+    # Accept legacy naive values and offset-qualified values in the same file.
     if not df_MVBS.empty:
-        if df_MVBS["last_ping_time"].dt.tz is None:
-            df_MVBS["last_ping_time"] = df_MVBS["last_ping_time"].dt.tz_localize("UTC")
-        if df_MVBS["first_ping_time"].dt.tz is None:
-            df_MVBS["first_ping_time"] = df_MVBS["first_ping_time"].dt.tz_localize("UTC")
+        for column in ["first_ping_time", "last_ping_time"]:
+            df_MVBS[column] = pd.to_datetime(
+                df_MVBS[column], format="mixed", utc=True
+            )
 
     # Get MVBS files in the specified time range (only 1 slice)
     MVBS_filenames = sorted(
         df_MVBS[
-            (pd.to_datetime(df_MVBS["last_ping_time"]) >= start_time[0]) &
-            (pd.to_datetime(df_MVBS["first_ping_time"]) <= end_time[0])
+            (df_MVBS["last_ping_time"] >= start_time[0]) &
+            (df_MVBS["first_ping_time"] <= end_time[0])
         ]["MVBS_filename"].tolist()
     )
     logger.info(

--- a/src/echodataflow/operations/operations_acoustics.py
+++ b/src/echodataflow/operations/operations_acoustics.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import echopype as ep
+from echopype.qc import coerce_increasing_time, exist_reversed_time
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -45,8 +46,8 @@ class RawToSvResult:
 
 
 def _clean_reversed_ping_time(x):
-    if ep.qc.exist_reversed_time(x, "ping_time"):
-        ep.qc.coerce_increasing_time(x)
+    if exist_reversed_time(x, "ping_time"):
+        coerce_increasing_time(x)
     return x
 
 

--- a/src/echodataflow/operations/operations_acoustics.py
+++ b/src/echodataflow/operations/operations_acoustics.py
@@ -103,8 +103,8 @@ def convert_raw_to_Sv(
     return RawToSvResult(
         filename_raw=raw_path.name,
         filename_Sv=output_path.name,
-        first_ping_time=pd.to_datetime(ds_sv["ping_time"][0].values),
-        last_ping_time=pd.to_datetime(ds_sv["ping_time"][-1].values),
+        first_ping_time=pd.to_datetime(ds_sv["ping_time"][0].values, utc=True),
+        last_ping_time=pd.to_datetime(ds_sv["ping_time"][-1].values, utc=True),
     )
 
 
@@ -192,8 +192,10 @@ def create_MVBS(
 
     return CreateMVBSResult(
         mvbs_filename=item.mvbs_filename,
-        first_ping_time=pd.to_datetime(ds_MVBS["ping_time"][0].values),
-        last_ping_time=pd.to_datetime(ds_MVBS["ping_time"][-1].values),
+        # xarray stores these coordinates as timezone-naive numpy datetimes,
+        # but manifests consistently use UTC-aware datetime columns
+        first_ping_time=pd.to_datetime(ds_MVBS["ping_time"][0].values, utc=True),
+        last_ping_time=pd.to_datetime(ds_MVBS["ping_time"][-1].values, utc=True),
     )
 
 

--- a/tests/test_operations_create_MVBS.py
+++ b/tests/test_operations_create_MVBS.py
@@ -117,8 +117,8 @@ def test_create_MVBS_processes_one_time_slice(monkeypatch, tmp_path):
     }
     assert result == operations_acoustics.CreateMVBSResult(
         mvbs_filename="MVBS_20260101T000000.zarr",
-        first_ping_time=pd.Timestamp("2026-01-01T00:00:05"),
-        last_ping_time=pd.Timestamp("2026-01-01T00:09:55"),
+        first_ping_time=pd.Timestamp("2026-01-01T00:00:05Z"),
+        last_ping_time=pd.Timestamp("2026-01-01T00:09:55Z"),
     )
 
 

--- a/tests/test_operations_raw_to_Sv.py
+++ b/tests/test_operations_raw_to_Sv.py
@@ -51,8 +51,8 @@ def test_convert_raw_to_Sv_returns_structured_result(monkeypatch, tmp_path):
     assert result == operations_acoustics.RawToSvResult(
         filename_raw="example.raw",
         filename_Sv="example_Sv.zarr",
-        first_ping_time=pd.Timestamp("2026-01-01T00:00:00"),
-        last_ping_time=pd.Timestamp("2026-01-01T00:01:00"),
+        first_ping_time=pd.Timestamp("2026-01-01T00:00:00Z"),
+        last_ping_time=pd.Timestamp("2026-01-01T00:01:00Z"),
     )
     assert dataset.saved == {
         "store": Path(tmp_path) / "example_Sv.zarr",


### PR DESCRIPTION
In pandas v2 mixed format timestamps can get converted silently, but in v3 this would fail. This PR updates the code read/convert everything to UTC before any operations.

This PR also did a hotfix of `echopype.qc` import since on the Lasker current env echopype v0.11.1 is installed rather than an editable version.